### PR TITLE
Split runtime abort/asserts and wasm app abort/assert. 

### DIFF
--- a/scripts/bindgen.py
+++ b/scripts/bindgen.py
@@ -135,8 +135,8 @@ def bindgen(apiName, spec, **kwargs):
                     s += retTypeCName + '* __retPtr = (' + retTypeCName + '*)((char*)_mem + *(i32*)&_sp[0]);\n'
 
                     s += '\t{\n'
-                    s += '\t\tOC_ASSERT(((char*)__retPtr >= (char*)_mem) && (((char*)__retPtr - (char*)_mem) < m3_GetMemorySize(runtime)), "return pointer is out of bounds");\n'
-                    s += '\t\tOC_ASSERT((char*)__retPtr + sizeof(' + retTypeCName + ') <= ((char*)_mem + m3_GetMemorySize(runtime)), "return pointer is out of bounds");\n'
+                    s += '\t\tOC_ASSERT_DIALOG(((char*)__retPtr >= (char*)_mem) && (((char*)__retPtr - (char*)_mem) < m3_GetMemorySize(runtime)), "return pointer is out of bounds");\n'
+                    s += '\t\tOC_ASSERT_DIALOG((char*)__retPtr + sizeof(' + retTypeCName + ') <= ((char*)_mem + m3_GetMemorySize(runtime)), "return pointer is out of bounds");\n'
                     s += '\t}\n'
 
             for argIndex, arg in enumerate(decl['args']):
@@ -178,8 +178,8 @@ def bindgen(apiName, spec, **kwargs):
                         printError("binding '" + name + "' missing pointer length decoration for param '" + argName + "'")
                     else:
                         s += '\t{\n'
-                        s += '\t\tOC_ASSERT(((char*)'+ argName + ' >= (char*)_mem) && (((char*)'+ argName +' - (char*)_mem) < m3_GetMemorySize(runtime)), "parameter \''+argName+'\' is out of bounds");\n'
-                        s += '\t\tOC_ASSERT((char*)' + argName + ' + '
+                        s += '\t\tOC_ASSERT_DIALOG(((char*)'+ argName + ' >= (char*)_mem) && (((char*)'+ argName +' - (char*)_mem) < m3_GetMemorySize(runtime)), "parameter \''+argName+'\' is out of bounds");\n'
+                        s += '\t\tOC_ASSERT_DIALOG((char*)' + argName + ' + '
 
                         proc = argLen.get('proc')
                         if proc != None:

--- a/src/platform/native_debug.c
+++ b/src/platform/native_debug.c
@@ -7,7 +7,8 @@
 **************************************************************************/
 #include <stdio.h>
 
-#include "app/app.h"
+#include "util/memory.h"
+#include "util/strings.h"
 #include "platform_debug.c"
 //----------------------------------------------------------------
 // Logging
@@ -102,14 +103,7 @@ _Noreturn void oc_abort_ext(const char* file, const char* function, int line, co
                                 note.ptr);
 
     oc_log_error(msg.ptr);
-
-    oc_str8_list options = { 0 };
-    oc_str8_list_push(scratch.arena, &options, OC_STR8("OK"));
-
-    oc_alert_popup(OC_STR8("Fatal Error"), msg, options);
-
-    //TODO: could terminate more gracefully?
-    exit(-1);
+    abort();
 }
 
 _Noreturn void oc_assert_fail(const char* file, const char* function, int line, const char* src, const char* fmt, ...)
@@ -130,12 +124,5 @@ _Noreturn void oc_assert_fail(const char* file, const char* function, int line, 
                                 oc_str8_ip(note));
 
     oc_log_error(msg.ptr);
-
-    oc_str8_list options = { 0 };
-    oc_str8_list_push(scratch.arena, &options, OC_STR8("OK"));
-
-    oc_alert_popup(OC_STR8("Assertion Failed"), msg, options);
-
-    //TODO: could terminate more gracefully?
-    exit(-1);
+    abort();
 }

--- a/src/platform/platform_debug.c
+++ b/src/platform/platform_debug.c
@@ -5,6 +5,7 @@
 *  See LICENSE.txt for licensing information
 *
 **************************************************************************/
+#include <stdarg.h>
 #include "platform_debug.h"
 
 typedef struct oc_log_config

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -130,7 +130,15 @@ oc_runtime* oc_runtime_get(void);
 oc_wasm_env* oc_runtime_get_env(void);
 oc_str8 oc_runtime_get_wasm_memory(void);
 
-void orca_wasm3_abort(IM3Runtime runtime, M3Result res, const char* file, const char* function, int line, const char* msg);
-#define ORCA_WASM3_ABORT(runtime, err, msg) orca_wasm3_abort(runtime, err, __FILE__, __FUNCTION__, __LINE__, msg)
+void oc_abort_ext_dialog(const char* file, const char* function, int line, const char* fmt, ...);
+void oc_assert_fail_dialog(const char* file, const char* function, int line, const char* test, const char* fmt, ...);
+
+#define _OC_ASSERT_DIALOG_(test, fmt, ...) \
+    ((test) || (oc_assert_fail_dialog(__FILE__, __FUNCTION__, __LINE__, #test, fmt, ##__VA_ARGS__), 0))
+#define OC_ASSERT_DIALOG(test, ...) \
+    _OC_ASSERT_DIALOG_(test, OC_VA_NOPT("", ##__VA_ARGS__) OC_ARG1(__VA_ARGS__) OC_VA_COMMA_TAIL(__VA_ARGS__))
+
+void oc_wasm3_trap(IM3Runtime runtime, M3Result res, const char* file, const char* function, int line, const char* msg);
+#define OC_WASM3_TRAP(runtime, err, msg) oc_wasm3_trap(runtime, err, __FILE__, __FUNCTION__, __LINE__, msg)
 
 #endif //__RUNTIME_H_

--- a/src/runtime_memory.c
+++ b/src/runtime_memory.c
@@ -151,13 +151,13 @@ oc_wasm_addr oc_wasm_arena_push(oc_wasm_addr arena, u64 size)
     M3Result res = m3_Call(env->exports[OC_EXPORT_ARENA_PUSH], 2, args);
     if(res)
     {
-        ORCA_WASM3_ABORT(env->m3Runtime, res, "Runtime error");
+        OC_WASM3_TRAP(env->m3Runtime, res, "Runtime error");
     }
 
     res = m3_GetResults(env->exports[OC_EXPORT_ARENA_PUSH], 1, retPointers);
     if(res)
     {
-        ORCA_WASM3_ABORT(env->m3Runtime, res, "Runtime error");
+        OC_WASM3_TRAP(env->m3Runtime, res, "Runtime error");
     }
 
     return (retValues[0]);

--- a/src/wasmbind/core_api.json
+++ b/src/wasmbind/core_api.json
@@ -33,7 +33,7 @@
 },
 {
 	"name": "oc_bridge_assert_fail",
-	"cname": "oc_assert_fail",
+	"cname": "oc_assert_fail_dialog",
 	"ret": {"name": "void", "tag": "v"},
 	"args": [ {"name": "file",
 			   "type": {"name": "const char*", "tag": "p"},
@@ -53,7 +53,7 @@
 },
 {
 	"name": "oc_bridge_abort_ext",
-	"cname": "oc_abort_ext",
+	"cname": "oc_abort_ext_dialog",
 	"ret": {"name": "void", "tag": "v"},
 	"args": [ {"name": "file",
 			   "type": {"name": "const char*", "tag": "p"},


### PR DESCRIPTION
This removes the dependency on `app/app.h` from `platform/native_debug.c`. This way we can pull subsets of the orca platform layer for native command line tools without having to pull all the app/windowing layer.

- Always log and abort normally from native code. 
- Display a dialog and exit silently when aborting/asserting from wasm code or bindings bound checks