### PR TITLE
Fix runtime thread getting stuck in a loop on resize

### DIFF
--- a/src/graphics/gl_canvas.c
+++ b/src/graphics/gl_canvas.c
@@ -1143,6 +1143,11 @@ void oc_gl_render_batch(oc_gl_canvas_backend* backend,
     //      so the maximum _allowed_ group count is one less.
     maxWorkGroupCount--;
 
+    if (maxWorkGroupCount <= 0) {
+        oc_log_error("max work group count is non-positive: %d\n", maxWorkGroupCount);
+        return;
+    }
+
     glUseProgram(backend->pathSetup);
 
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, backend->tileQueueCountBuffer);


### PR DESCRIPTION
Fixes issue orca-app/orca#12

Every now and then while resizing the window, gl error 1281 gets printed. This does not cause any noticable issues to the program. However, other times a different error 1282 gets printed and my program freezes, no longer updating the viewport or responding to input. I tracked the issue down to oc_gl_grow_buffer_if_needed().  When this function is called with the path queues buffer from oc_gl_render_batch(), the second line of the function, `glBindBuffer(GL_SHADER_STORAGE_BUFFER, buffer);` causes the gl error. While debugging on my machine, this buffer handle is always 27.

I don't know enough about the orca system or opengl to track down why the glBindBuffer call is failing sometimes. However, I was able to fix the downstream effect of the runtime thread getting stuck in an infinite loop. Whenever the glBindBuffer for the path queues fails with error 1282, the call to `glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_COUNT, 0, &maxWorkGroupCount);` in oc_gl_render_batch() fails to report a max work group count. This value is subsequently decremented by one making it negative, and then it is used in a loop to "increment" a loop counter causing the runtime thread to get stuck in a loop. To avoid this I am just bailing out of oc_gl_render_batch() if maxWorkGroupCount is non-positive.

The Orca team may have insight into why the glBindBuffer is failing or want to fix this in a different way, but this has been working for me so I thought I would contribute it back and share some info.