### PR TITLE
oc_get_host_platform() -> oc_get_host_platform(void)

### DIFF
--- a/src/platform/osx_platform.c
+++ b/src/platform/osx_platform.c
@@ -8,14 +8,13 @@
 #include "platform.h"
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-	oc_host_platform oc_get_host_platform()
-	{
-		return OC_HOST_PLATFORM_MACOS;
-	}
+oc_host_platform oc_get_host_platform(void)
+{
+    return OC_HOST_PLATFORM_MACOS;
+}
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -121,7 +121,7 @@ typedef enum
     OC_HOST_PLATFORM_WINDOWS,
 } oc_host_platform;
 
-ORCA_API oc_host_platform oc_get_host_platform();
+ORCA_API oc_host_platform oc_get_host_platform(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/platform/win32_platform.c
+++ b/src/platform/win32_platform.c
@@ -8,14 +8,13 @@
 #include "platform.h"
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-	oc_host_platform oc_get_host_platform()
-	{
-		return OC_HOST_PLATFORM_WINDOWS;
-	}
+oc_host_platform oc_get_host_platform(void)
+{
+    return OC_HOST_PLATFORM_WINDOWS;
+}
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
Minor syntax fix I ran into when I was doing zig bindings. The extra spacing changes are due to clang-format.