### PR TITLE
Install script fixes

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -566,6 +566,8 @@ def install(args):
     dest = install_dir()
     bin_dir = os.path.join(dest, "bin")
     src_dir = os.path.join(dest, "src")
+    build_dir = os.path.join(dest, "build", "bin")
+    res_dir = os.path.join(dest, "resources")
     version_file = os.path.join(dest, ".orcaversion")
 
     version = orca_version()
@@ -588,6 +590,8 @@ def install(args):
 
     yeetdir(bin_dir)
     yeetdir(src_dir)
+    yeetdir(build_dir)
+    yeetdir(res_dir)
     yeetfile(version_file)
 
     # The MS Store version of Python does some really stupid stuff with AppData:
@@ -603,13 +607,20 @@ def install(args):
     if platform.system() == "Windows":
         subprocess.run(["scripts\\mkdir.bat", bin_dir], check=True)
         subprocess.run(["scripts\\mkdir.bat", src_dir], check=True)
+        subprocess.run(["scripts\\mkdir.bat", build_dir], check=True)
+        subprocess.run(["scripts\\mkdir.bat", res_dir], check=True)
         subprocess.run(["scripts\\touch.bat", version_file], check=True)
 
     shutil.copytree("scripts", os.path.join(bin_dir, "sys_scripts"))
     shutil.copy("orca", bin_dir)
     shutil.copytree("src", src_dir, dirs_exist_ok=True)
+    shutil.copytree("resources", res_dir, dirs_exist_ok=True)
     if platform.system() == "Windows":
         shutil.copy("orca.bat", bin_dir)
+        shutil.copy("build\\bin\\orca.dll", build_dir)
+        shutil.copy("build\\bin\\orca_runtime.exe", build_dir)
+        shutil.copy("ext\\angle\\bin\\libEGL.dll", build_dir)
+        shutil.copy("ext\\angle\\bin\\libGLESv2.dll", build_dir)
     with open(version_file, "w") as f:
         f.write(version)
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -610,6 +610,9 @@ def install(args):
         subprocess.run(["scripts\\mkdir.bat", build_dir], check=True)
         subprocess.run(["scripts\\mkdir.bat", res_dir], check=True)
         subprocess.run(["scripts\\touch.bat", version_file], check=True)
+    else:
+        # unfortunately need to do this since build_dir is nested
+        os.makedirs(build_dir, exist_ok=True)
 
     shutil.copytree("scripts", os.path.join(bin_dir, "sys_scripts"))
     shutil.copy("orca", bin_dir)
@@ -621,6 +624,13 @@ def install(args):
         shutil.copy("build\\bin\\orca_runtime.exe", build_dir)
         shutil.copy("ext\\angle\\bin\\libEGL.dll", build_dir)
         shutil.copy("ext\\angle\\bin\\libGLESv2.dll", build_dir)
+    else:
+        shutil.copy("build/bin/liborca.dylib", build_dir)
+        shutil.copy("build/bin/mtl_renderer.metallib", build_dir)
+        shutil.copy("build/bin/orca_runtime", build_dir)
+        shutil.copy("ext/angle/bin/libEGL.dylib", build_dir)
+        shutil.copy("ext/angle/bin/libGLESv2.dylib", build_dir)
+
     with open(version_file, "w") as f:
         f.write(version)
 


### PR DESCRIPTION
The motivation for these changes is to fix issues I ran into while updating the zig samples to live in an external repo. While we have a long-term plan to move the tooling away from python, this should unblock anyone trying to use the `orca bundle` commands for an external project in the near term, as well as anyone trying to build the zig samples. 