### PR TITLE
couple fixes for _Generic macro compile errors

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -4080,8 +4080,8 @@ oc_ui_text_box_result oc_ui_text_box_str8(oc_str8 name, oc_arena* arena, oc_str8
     {
         oc_str32 oldCodepoints = oc_utf8_push_to_codepoints(&ui->frameArena, text);
         oc_str32 codepoints = oldCodepoints;
-        ui->editCursor = oc_clamp(ui->editCursor, 0, codepoints.len);
-        ui->editMark = oc_clamp(ui->editMark, 0, codepoints.len);
+        ui->editCursor = oc_clamp(ui->editCursor, 0, (i32)codepoints.len);
+        ui->editMark = oc_clamp(ui->editMark, 0, (i32)codepoints.len);
 
         //NOTE replace selection with input codepoints
         oc_str32 input = oc_input_text_utf32(&ui->frameArena, &ui->input);

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -109,10 +109,18 @@ inline T oc_cube(T a)
     //NOTE(martin): this macros helps generate variants of a generic 'template' for all arithmetic types.
     // the def parameter must be a macro that takes a type, and optional arguments
 
-    #define oc_tga_variants(def, ...)                                                                       \
-        def(u8, ##__VA_ARGS__) def(i8, ##__VA_ARGS__) def(u16, ##__VA_ARGS__) def(i16, ##__VA_ARGS__)       \
-            def(u32, ##__VA_ARGS__) def(i32, ##__VA_ARGS__) def(u64, ##__VA_ARGS__) def(i64, ##__VA_ARGS__) \
-                def(f32, ##__VA_ARGS__) def(f64, ##__VA_ARGS__)
+    // NOTE(reuben): msvc and clang **on Windows** define size_t as our u64 so we don't add a definition for it
+    #if OC_PLATFORM_WINDOWS
+        #define oc_tga_variants(def, ...)                                                                       \
+            def(u8, ##__VA_ARGS__) def(i8, ##__VA_ARGS__) def(u16, ##__VA_ARGS__) def(i16, ##__VA_ARGS__)       \
+                def(u32, ##__VA_ARGS__) def(i32, ##__VA_ARGS__) def(u64, ##__VA_ARGS__) def(i64, ##__VA_ARGS__) \
+                    def(f32, ##__VA_ARGS__) def(f64, ##__VA_ARGS__)
+    #else
+        #define oc_tga_variants(def, ...)                                                                       \
+            def(u8, ##__VA_ARGS__) def(i8, ##__VA_ARGS__) def(u16, ##__VA_ARGS__) def(i16, ##__VA_ARGS__)       \
+                def(u32, ##__VA_ARGS__) def(i32, ##__VA_ARGS__) def(u64, ##__VA_ARGS__) def(i64, ##__VA_ARGS__) \
+                    def(f32, ##__VA_ARGS__) def(f64, ##__VA_ARGS__) def(size_t, ##__VA_ARGS__)
+    #endif
 
     // This macro generates one _Generic association between a type and its variant
     #define oc_tga_association(type, name) , type : OC_CAT3(name, _, type)
@@ -136,10 +144,10 @@ inline T oc_cube(T a)
         static inline type OC_CAT3(oc_cube, _, type)(type a) { return (a * a * a); }
 
 //NOTE(martin): instantiante our templates for all arithmetic types
-oc_tga_variants(oc_min_def)
-    oc_tga_variants(oc_max_def)
-        oc_tga_variants(oc_square_def)
-            oc_tga_variants(oc_cube_def)
+oc_tga_variants(oc_min_def);
+oc_tga_variants(oc_max_def);
+oc_tga_variants(oc_square_def);
+oc_tga_variants(oc_cube_def);
 
     //NOTE(martin): generate the _Generic associations between each type and its associated variant
     #define oc_min(a, b) oc_tga_select_binary(oc_min, a, b)


### PR DESCRIPTION
* support size_t explicitly for non-MSVC platforms
* added casts in a couple places to ensure oc_clamp() deals with the same types