### PR TITLE
Add notes on possible additional xcode setup for mac users

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,8 @@ The Orca command-line tools must be installed to your system in order to use the
 	- Please note the version requirement! Orca requires C11 atomics, which were only added to MSVC in late 2022.
 - Xcode command-line tools (Mac only)
 	- These can be installed with `xcode-select --install`.
+        - If xcode-select --print-path prints /Library/Developer/CommandLineTools
+		then run `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer` (Be sure the Xcode app is installed, not just the command line tools).
 
 ### Installation instructions
 


### PR DESCRIPTION
When trying to install Orca on mac this message appeared: "xcrun: error: unable to find utility "metal", not a developer tool or in PATH" The instructions as explained here solve the issue: https://github.com/gfx-rs/gfx/issues/2309#issuecomment-506130902