### PR TITLE
Fix off by one bug in strncmp

### DIFF
--- a/src/libc-shim/src/string.c
+++ b/src/libc-shim/src/string.c
@@ -69,7 +69,7 @@ int strcmp(const char* s1, const char* s2)
 int strncmp(const char* s1, const char* s2, size_t n)
 {
     size_t i = 0;
-    while(i < n && s1[i] != '\0' && s1[i] == s2[i])
+    while(i < n-1 && s1[i] != '\0' && s1[i] == s2[i])
     {
         i++;
     }


### PR DESCRIPTION
When calling strncmp with an n value that is less than the length of the strings being compared, then the index variable i was being incremented one too many times and comparing one extra character. This patch fixes that.