### PR TITLE
Get CI working for the runtime and create releases when tags are pushed

### DIFF
--- a/.github/workflows/build-runtime.yaml
+++ b/.github/workflows/build-runtime.yaml
@@ -1,0 +1,76 @@
+name: build-runtime
+
+# TODO: scope more tightly or something
+on: [push, workflow_call]
+
+jobs:
+  build-win:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          orcadev.bat build-runtime
+
+      - name: Zip
+        shell: powershell
+        run: |
+          Copy-Item -Path build -Destination orca-runtime-win -Recurse
+          Compress-Archive -Path orca-runtime-win -DestinationPath orca-runtime-win.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: orca-runtime-win
+          path: orca-runtime-win.zip
+
+  build-macos-x64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: Build
+        run: ./orcadev build-runtime
+      
+      - name: Tar
+        run: |
+          cp -r build orca-runtime-mac-x64
+          tar -c -z -f orca-runtime-mac-x64.tar.gz orca-runtime-mac-x64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: orca-runtime-mac-x64
+          path: orca-runtime-mac-x64.tar.gz
+
+  build-macos-arm64:
+    runs-on: [self-hosted, macos]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: Build
+        run: ./orcadev build-runtime
+      
+      - name: Tar
+        run: |
+          cp -r build orca-runtime-mac-arm64
+          tar -c -z -f orca-runtime-mac-arm64.tar.gz orca-runtime-mac-arm64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: orca-runtime-mac-arm64
+          path: orca-runtime-mac-arm64.tar.gz
+

--- a/.github/workflows/build-tool.yaml
+++ b/.github/workflows/build-tool.yaml
@@ -1,7 +1,7 @@
 name: build-tool
 
 # TODO: scope more tightly or something
-on: [push]
+on: [push, workflow_call]
 
 jobs:
   build-win:
@@ -16,10 +16,10 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           orcadev.bat build-tool
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: orca-win
           path: build/bin/orca.exe
@@ -41,7 +41,7 @@ jobs:
           cp build/bin/orca orca-mac-x64
           tar -cf orca-mac-x64.tar orca-mac-x64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: orca-mac-x64.tar
           path: orca-mac-x64.tar
@@ -63,7 +63,7 @@ jobs:
           cp build/bin/orca orca-mac-arm64
           tar -cf orca-mac-arm64.tar orca-mac-arm64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: orca-mac-arm64.tar
           path: orca-mac-arm64.tar
@@ -75,11 +75,11 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
       
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: orca-mac-x64.tar
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: orca-mac-arm64.tar
       
@@ -98,7 +98,7 @@ jobs:
         run: |
           tar -cf orca.tar orca
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: orca-mac.tar
           path: orca.tar

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,27 @@
+name: create-release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-tool:
+    uses: ./.github/workflows/build-tool.yaml
+
+  release:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+      needs: build-tool
+      steps: 
+        - uses: actions/download-artifact@v4
+          with:
+            # when name is not specified, all artifacts from this run will be downloaded
+            path: releases
+            merge-multiple: true
+
+        - uses: ncipollo/release-action@v1
+          with:
+            artifacts: "releases/*"
+

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -9,11 +9,14 @@ jobs:
   build-tool:
     uses: ./.github/workflows/build-tool.yaml
 
+  build-runtime:
+    uses: ./.github/workflows/build-runtime.yaml
+
   release:
       runs-on: ubuntu-latest
       permissions:
         contents: write
-      needs: build-tool
+      needs: [build-tool, build-runtime]
       steps: 
         - uses: actions/download-artifact@v4
           with:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -542,8 +542,6 @@ def build_tool(args):
         else:
             libs = []
 
-        srcFiles = ["main.c"] if platform.system() == "Windows" else ["main.c", "../platform/osx_path.m"]
-
         subprocess.run([
             "clang",
             "-std=c11",
@@ -555,7 +553,7 @@ def build_tool(args):
             *libs,
             "-MJ", "build/main.json",
             "-o", f"build/bin/{outname}",
-            *srcFiles
+            "main.c"
         ], check=True)
 
         with open("build/compile_commands.json", "w") as f:


### PR DESCRIPTION
- Fixed build-tool script on mac
- Created a build-runtime workflow
- Created a create-release workflow that runs whenever a tag is pushed
  - This builds the cli tool and the runtime for all currently supported platforms and creates a new release

I don't know how the self-hosted runner for mac arm64 works exactly, but it understandably doesn't run in my fork where I was developing. I believe it will only run in the base repo, so I haven't been able to test that yet.

I think this is at least a good start for getting CI working for the runtime and creating releases. This is my first time touching CI / github actions so please feel free to criticize or steer me in a different direction if anything feels off.

