### PR TITLE
add null terminator in oc_win32_wide_to_utf8

### DIFF
--- a/src/platform/win32_string_helpers.c
+++ b/src/platform/win32_string_helpers.c
@@ -25,8 +25,9 @@ oc_str8 oc_win32_wide_to_utf8(oc_arena* arena, oc_str16 s)
 {
     oc_str8 res = { 0 };
     res.len = WideCharToMultiByte(CP_UTF8, 0, s.ptr, s.len, NULL, 0, NULL, NULL);
-    res.ptr = oc_arena_push_array(arena, u8, res.len);
+    res.ptr = oc_arena_push_array(arena, u8, res.len + 1);
     WideCharToMultiByte(CP_UTF8, 0, s.ptr, s.len, res.ptr, res.len, NULL, NULL);
+    res.ptr[res.len] = '\0';
     return (res);
 }
 


### PR DESCRIPTION
This commit fixes oc_win32_wide_to_utf8 so that it follows the convention that any string helper taking an arena as an argument will allocate and extra char and null terminate the string.