### PR TITLE
Use DXC compiler in dawn D3D12 backend

### DIFF
--- a/src/graphics/wgpu_renderer.c
+++ b/src/graphics/wgpu_renderer.c
@@ -629,7 +629,16 @@ oc_canvas_renderer oc_canvas_renderer_create(void)
 
         renderer->limits = supported.limits;
 
+        int enabledToggleCount = 1;
+        const char* enabledToggles[] = { "use_dxc" };
+
         WGPUDeviceDescriptor desc = {
+            .nextInChain = &((WGPUDawnTogglesDescriptor){
+                                 .chain.sType = WGPUSType_DawnTogglesDescriptor,
+                                 .enabledToggleCount = enabledToggleCount,
+                                 .enabledToggles = enabledToggles,
+                             })
+                                .chain,
             .requiredLimits = &(WGPURequiredLimits){ .limits = supported.limits },
         };
 


### PR DESCRIPTION
This toggles on the use of the new DXC shader compiler for compiling canvas shaders on Windows, which cuts startup time by around 50%.