### PR TITLE
Support whitespaces in sdk-path for Windows

### DIFF
--- a/samples/breakout/build.bat
+++ b/samples/breakout/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-for /f %%i in ('orca sdk-path') do set ORCA_DIR=%%i
+for /f "delims=" %%i in ('"orca sdk-path"') do set ORCA_DIR="%%i"
 
 :: common flags to build wasm modules
 set wasmFlags=--target=wasm32^

--- a/samples/clock/build.bat
+++ b/samples/clock/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-for /f %%i in ('orca sdk-path') do set ORCA_DIR=%%i
+for /f "delims=" %%i in ('"orca sdk-path"') do set ORCA_DIR="%%i"
 
 :: common flags to build wasm modules
 set wasmFlags=--target=wasm32^

--- a/samples/fluid/build.bat
+++ b/samples/fluid/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-for /f %%i in ('orca sdk-path') do set ORCA_DIR=%%i
+for /f "delims=" %%i in ('"orca sdk-path"') do set ORCA_DIR="%%i"
 
 set shaders=src/shaders/advect.glsl^
 	src/shaders/blit_div_fragment.glsl^

--- a/samples/triangle/build.bat
+++ b/samples/triangle/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-for /f %%i in ('orca sdk-path') do set ORCA_DIR=%%i
+for /f "delims=" %%i in ('"orca sdk-path"') do set ORCA_DIR="%%i"
 
 :: common flags to build wasm modules
 set wasmFlags=--target=wasm32^

--- a/samples/ui/build.bat
+++ b/samples/ui/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-for /f %%i in ('orca sdk-path') do set ORCA_DIR=%%i
+for /f "delims=" %%i in ('"orca sdk-path"') do set ORCA_DIR="%%i"
 
 :: common flags to build wasm modules
 set wasmFlags=--target=wasm32^


### PR DESCRIPTION
The `build.bat` for each sample fails on Windows if orca sdk is in a path with spaces. This change allows paths with spaces. 
