### PR TITLE
Fix bleeding on image edges

### DIFF
--- a/sketches/check-bleeding/build.sh
+++ b/sketches/check-bleeding/build.sh
@@ -10,10 +10,10 @@ LIBS="-L$LIBDIR -lorca"
 FLAGS="-mmacos-version-min=10.15.4 -DOC_DEBUG -DLOG_COMPILE_DEBUG"
 
 mkdir -p $BINDIR
-clang -g $FLAGS $LIBS $INCLUDES -o $BINDIR/example_image main.c
+clang -g $FLAGS $LIBS $INCLUDES -o $BINDIR/test_bleeding main.c
 
 cp $LIBDIR/liborca.dylib $BINDIR/
 cp $LIBDIR/libwebgpu.dylib $BINDIR/
 
 
-install_name_tool -add_rpath "@executable_path" $BINDIR/example_image
+install_name_tool -add_rpath "@executable_path" $BINDIR/test_bleeding

--- a/sketches/check-bleeding/main.c
+++ b/sketches/check-bleeding/main.c
@@ -1,0 +1,168 @@
+/*************************************************************************
+*
+*  Orca
+*  Copyright 2023 Martin Fouilleul and the Orca project contributors
+*  See LICENSE.txt for licensing information
+*
+**************************************************************************/
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define _USE_MATH_DEFINES //NOTE: necessary for MSVC
+#include <math.h>
+
+#include "orca.h"
+#include "graphics/wgpu_renderer_debug.h"
+
+int main()
+{
+    oc_init();
+
+    oc_rect windowRect = { .x = 100, .y = 100, .w = 800, .h = 700 };
+    oc_window window = oc_window_create(windowRect, OC_STR8("test"), 0);
+
+    oc_rect contentRect = oc_window_get_content_rect(window);
+
+    oc_canvas_renderer renderer = oc_canvas_renderer_create();
+    if(oc_canvas_renderer_is_nil(renderer))
+    {
+        oc_log_error("Error: couldn't create renderer\n");
+        return (-1);
+    }
+
+    oc_wgpu_canvas_debug_display_options displayOptions = {
+        .showTileBorders = true,
+    };
+
+    oc_wgpu_canvas_debug_set_display_options(renderer, &displayOptions);
+
+    oc_surface surface = oc_canvas_surface_create_for_window(renderer, window);
+    if(oc_surface_is_nil(surface))
+    {
+        oc_log_error("Error: couldn't create surface\n");
+        return (-1);
+    }
+
+    oc_canvas_context context = oc_canvas_context_create();
+    if(oc_canvas_context_is_nil(context))
+    {
+        oc_log_error("Error: couldn't create canvas\n");
+        return (-1);
+    }
+
+    //NOTE: create image
+    oc_arena_scope scratch = oc_scratch_begin();
+
+    oc_str8 imagePath = oc_path_executable_relative(scratch.arena, OC_STR8("../../resources/square_small.png"));
+    oc_image image = oc_image_create_from_path(renderer, imagePath, false);
+    oc_vec2 imageSize = oc_image_size(image);
+
+    oc_scratch_end(scratch);
+    // start app
+    oc_window_bring_to_front(window);
+    oc_window_focus(window);
+
+    f32 x = 100;
+    f32 y = 100;
+    f32 width = 128;
+    f32 height = 128;
+
+    while(!oc_should_quit())
+    {
+        scratch = oc_scratch_begin();
+
+        oc_pump_events(0);
+        oc_event* event = 0;
+        while((event = oc_next_event(scratch.arena)) != 0)
+        {
+            switch(event->type)
+            {
+                case OC_EVENT_WINDOW_CLOSE:
+                {
+                    oc_request_quit();
+                }
+                break;
+
+                case OC_EVENT_KEYBOARD_KEY:
+                {
+                    if(event->key.action == OC_KEY_PRESS || event->key.action == OC_KEY_REPEAT)
+                    {
+                        if(event->key.keyCode == OC_KEY_LEFT)
+                        {
+                            if(event->key.mods & OC_KEYMOD_SHIFT)
+                            {
+                                x--;
+                            }
+                            else
+                            {
+                                width--;
+                            }
+                        }
+                        else if(event->key.keyCode == OC_KEY_RIGHT)
+                        {
+                            if(event->key.mods & OC_KEYMOD_SHIFT)
+                            {
+                                x++;
+                            }
+                            else
+                            {
+                                width++;
+                            }
+                        }
+                        else if(event->key.keyCode == OC_KEY_UP)
+                        {
+                            if(event->key.mods & OC_KEYMOD_SHIFT)
+                            {
+                                y--;
+                            }
+                            else
+                            {
+                                height--;
+                            }
+                        }
+                        else if(event->key.keyCode == OC_KEY_DOWN)
+                        {
+                            if(event->key.mods & OC_KEYMOD_SHIFT)
+                            {
+                                y++;
+                            }
+                            else
+                            {
+                                height++;
+                            }
+                        }
+                    }
+                }
+                break;
+
+                default:
+                    break;
+            }
+        }
+
+        oc_set_color_rgba(0, 0, 0, 1);
+        oc_clear();
+
+        oc_set_color_rgba(0, 1, 0, 1);
+        oc_rectangle_fill(x, y, width, height);
+
+        oc_set_color_rgba(1, 1, 1, 1);
+        oc_image_draw(image, (oc_rect){ x, y, width, height });
+
+        oc_canvas_render(renderer, context, surface);
+        oc_canvas_present(renderer, surface);
+
+        oc_scratch_end(scratch);
+    }
+
+    oc_image_destroy(image);
+    //    oc_canvas_renderer_destroy(renderer);
+    oc_surface_destroy(surface);
+    oc_window_destroy(window);
+
+    oc_terminate();
+
+    return (0);
+}

--- a/sketches/image/main.c
+++ b/sketches/image/main.c
@@ -24,18 +24,22 @@ int main()
 
     oc_rect contentRect = oc_window_get_content_rect(window);
 
-    //NOTE: create surface
-    oc_surface surface = oc_surface_create_for_window(window, OC_CANVAS);
-    if(oc_surface_is_nil(surface))
+    oc_canvas_renderer renderer = oc_canvas_renderer_create();
+    if(oc_canvas_renderer_is_nil(renderer))
     {
-        oc_log_error("couldn't create surface\n");
+        oc_log_error("Error: couldn't create renderer\n");
         return (-1);
     }
-    oc_surface_swap_interval(surface, 0);
 
-    //NOTE: create canvas
-    oc_canvas canvas = oc_canvas_create();
-    if(oc_canvas_is_nil(canvas))
+    oc_surface surface = oc_canvas_surface_create_for_window(renderer, window);
+    if(oc_surface_is_nil(surface))
+    {
+        oc_log_error("Error: couldn't create surface\n");
+        return (-1);
+    }
+
+    oc_canvas_context context = oc_canvas_context_create();
+    if(oc_canvas_context_is_nil(context))
     {
         oc_log_error("Error: couldn't create canvas\n");
         return (-1);
@@ -45,11 +49,11 @@ int main()
     oc_arena_scope scratch = oc_scratch_begin();
 
     oc_str8 imagePath = oc_path_executable_relative(scratch.arena, OC_STR8("../../resources/triceratops.png"));
-    oc_image image = oc_image_create_from_file(surface, imagePath, false);
+    oc_image image = oc_image_create_from_path(renderer, imagePath, false);
     oc_vec2 imageSize = oc_image_size(image);
 
     oc_str8 imagePath2 = oc_path_executable_relative(scratch.arena, OC_STR8("../../resources/Top512.png"));
-    oc_image image2 = oc_image_create_from_file(surface, imagePath2, false);
+    oc_image image2 = oc_image_create_from_path(renderer, imagePath2, false);
     oc_vec2 imageSize2 = oc_image_size(image2);
 
     oc_scratch_end(scratch);
@@ -78,8 +82,6 @@ int main()
             }
         }
 
-        oc_surface_select(surface);
-
         oc_set_color_rgba(0, 1, 1, 1);
         oc_clear();
 
@@ -103,17 +105,17 @@ int main()
 
 			oc_image_draw(image2, (oc_rect){300, 200, 300, 300});
 */
-        oc_image_draw(image, (oc_rect){ 100, 100, 300, 300 });
+        oc_image_draw(image, (oc_rect){ 100, 100, 362, 256 });
         oc_image_draw(image2, (oc_rect){ 300, 200, 300, 300 });
 
-        oc_render(canvas);
-        oc_surface_present(surface);
+        oc_canvas_render(renderer, context, surface);
+        oc_canvas_present(renderer, surface);
 
         oc_scratch_end(scratch);
     }
 
     oc_image_destroy(image);
-    oc_canvas_destroy(canvas);
+    //    oc_canvas_renderer_destroy(renderer);
     oc_surface_destroy(surface);
     oc_window_destroy(window);
 


### PR DESCRIPTION
Painting an image over a solid color rectangle would show some of the rectangle color bleeding through at the edges of the image of large upscaling factors.
 
My UV computation and filtering code was wrong, meaning we were sampling transparent pixels outside the texture when upscaling. This PR fixes these.  

Unfortunately, the wrong filtering also made the lack of mip-mapping less visible, because it was effectively doing some averaging of covered pixels. So this PR also makes this missing feature more visible, especially for large downscaling factors.  Proper downscaling should be addressed next.