### PR TITLE
fix cheatsheet_app.h correct types for oc_on_resize function

### DIFF
--- a/doc/cheatsheets/cheatsheet_app.h
+++ b/doc/cheatsheets/cheatsheet_app.h
@@ -19,7 +19,7 @@ void oc_on_mouse_wheel(f32 deltaX, f32 deltaY);
 void oc_on_key_down(oc_scan_code scan, oc_key_code key);
 void oc_on_key_up(oc_scan_code scan, oc_key_code key);
 void oc_on_frame_refresh(void);
-void oc_on_resize(f32 width, f32 height);
+void oc_on_resize(u32 width, u32 height);
 void oc_on_raw_event(oc_event* event);
 void oc_on_terminate(void);
 


### PR DESCRIPTION
I was going through samples and the cheat sheet for the app and noticed that there are wrong types in the cheat sheet.