### PR TITLE
increase microtar header name length

### DIFF
--- a/src/ext/microtar/microtar.c
+++ b/src/ext/microtar/microtar.c
@@ -28,7 +28,7 @@
 #include "microtar.h"
 
 typedef struct {
-  char name[100];
+  char name[227];
   char mode[8];
   char owner[8];
   char group[8];
@@ -36,10 +36,11 @@ typedef struct {
   char mtime[12];
   char checksum[8];
   char type;
-  char linkname[100];
-  char _padding[255];
+  char linkname[227];
+  char _padding[1];
 } mtar_raw_header_t;
 
+static_assert(sizeof(mtar_raw_header_t) == 512);
 
 static unsigned round_up(unsigned n, unsigned incr) {
   return n + (incr - n % incr) % incr;

--- a/src/ext/microtar/microtar.h
+++ b/src/ext/microtar/microtar.h
@@ -46,8 +46,8 @@ typedef struct {
   unsigned size;
   unsigned mtime;
   unsigned type;
-  char name[100];
-  char linkname[100];
+  char name[227];
+  char linkname[227];
 } mtar_header_t;
 
 


### PR DESCRIPTION
* Some of the test releases have names that are too long for the default microtar header, which was 100 characters. For example, this string is 104 characters: orca/test-release-4f124dd346/src/ext/wasm3/platforms/embedded/wm_w600/wasm3/extra/oremark_minimal.wasm.h The microtar behavior was to truncate the string from the beginning if it wouldn't fit in the harcoded buffer size, but this was causing errors on extract where the rebuilt path didn't exist since it was cutting off part of the prefix. 'orca' happens to be 4 characters in the example case!
* This change ups the sizes of name and linkname in the header to 227, which yields a raw header size of 512 bytes.