### PR TITLE
handle prefix entry for long paths in tar archives

### DIFF
--- a/src/ext/microtar/microtar.c
+++ b/src/ext/microtar/microtar.c
@@ -37,9 +37,19 @@ typedef struct {
   char checksum[8];
   char type;
   char linkname[100];
-  char _padding[255];
+
+  char magic[6];
+  char version[2];
+  char uname[32];
+  char gname[32];
+  char devmajor[8];
+  char devminor[8];
+  char prefix[155];
+
+  char _padding[12];
 } mtar_raw_header_t;
 
+static_assert(sizeof(mtar_raw_header_t) == 512);
 
 static unsigned round_up(unsigned n, unsigned incr) {
   return n + (incr - n % incr) % incr;
@@ -110,6 +120,7 @@ static int raw_to_header(mtar_header_t *h, const mtar_raw_header_t *rh) {
   h->type = rh->type;
   strncpy(h->name, rh->name, sizeof(h->name));
   strncpy(h->linkname, rh->linkname, sizeof(h->name));
+  strncpy(h->prefix, rh->prefix, sizeof(h->prefix));
 
   return MTAR_ESUCCESS;
 }
@@ -127,6 +138,7 @@ static int header_to_raw(mtar_raw_header_t *rh, const mtar_header_t *h) {
   rh->type = h->type ? h->type : MTAR_TREG;
   strncpy(rh->name, h->name, sizeof(h->name));
   strncpy(rh->linkname, h->linkname, sizeof(h->name));
+  strncpy(rh->prefix, h->prefix, sizeof(h->prefix));
 
   /* Calculate and write checksum */
   chksum = checksum(rh);

--- a/src/ext/microtar/microtar.h
+++ b/src/ext/microtar/microtar.h
@@ -48,6 +48,7 @@ typedef struct {
   unsigned type;
   char name[100];
   char linkname[100];
+  char prefix[155];
 } mtar_header_t;
 
 

--- a/src/tool/tarball.c
+++ b/src/tool/tarball.c
@@ -147,7 +147,10 @@ int untar(FILE* file, oc_str8 out_dir)
         if(h.type == MTAR_TDIR)
         {
             oc_arena_scope scratch = oc_scratch_begin();
-            oc_str8 dir_path = oc_path_append(scratch.arena, out_dir, OC_STR8(h.name));
+            oc_str8 dir_path = out_dir;
+            dir_path = oc_path_append(scratch.arena, dir_path, OC_STR8(h.prefix));
+            dir_path = oc_path_append(scratch.arena, dir_path, OC_STR8(h.name));
+
             bool ok = oc_sys_mkdirs(dir_path);
             oc_scratch_end(scratch);
             if(!ok)
@@ -167,7 +170,10 @@ int untar(FILE* file, oc_str8 out_dir)
                 break;
             }
 
-            oc_str8 path = oc_path_append(scratch.arena, out_dir, OC_STR8(h.name));
+            oc_str8 path = out_dir;
+            path = oc_path_append(scratch.arena, path, OC_STR8(h.prefix));
+            path = oc_path_append(scratch.arena, path, OC_STR8(h.name));
+
             bool ok = write_file_from_tar(path, &h, buf, h.size);
             oc_scratch_end(scratch);
             if(!ok)


### PR DESCRIPTION
Some of the test releases have names that are too long to fit in the name entry of the tar header, which is 100 characters. For example, this string is 104 characters: 
`orca/test-release-4f124dd346/src/ext/wasm3/platforms/embedded/wm_w600/wasm3/extra/oremark_minimal.wasm.h`
 And note that `orca` is 4 characters, which was perfectly cut off, making this extra hard to debug. :) However, there is an additional prefix field that's 155 characters that was added to the tar spec at some point, but microtar just wasn't exposing it. To avoid making too many changes to microtar this change simply exposes the additional prefix field and lets the orca cli tool handle appending the prefix.