### PR TITLE
Utilize the first bit in File flags

### DIFF
--- a/src/api.json
+++ b/src/api.json
@@ -6314,37 +6314,37 @@
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_OPEN_APPEND",
                                 "doc": "Open the file in 'append' mode. All writes append data at the end of the file.",
-                                "value": 2
+                                "value": 1
                             },
                             {
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_OPEN_TRUNCATE",
                                 "doc": "Truncate the file to 0 bytes when opening.",
-                                "value": 4
+                                "value": 2
                             },
                             {
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_OPEN_CREATE",
                                 "doc": "Create the file if it does not exist.",
-                                "value": 8
+                                "value": 4
                             },
                             {
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_OPEN_SYMLINK",
                                 "doc": "If the file is a symlink, open the symlink itself instead of following it.",
-                                "value": 16
+                                "value": 8
                             },
                             {
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_OPEN_NO_FOLLOW",
                                 "doc": "If the file is a symlink, the call to open will fail.",
-                                "value": 32
+                                "value": 16
                             },
                             {
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_OPEN_RESTRICT",
                                 "doc": "Reserved.",
-                                "value": 64
+                                "value": 32
                             }
                         ]
                     }
@@ -6376,13 +6376,13 @@
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_ACCESS_READ",
                                 "doc": "The file handle can be used for reading from the file.",
-                                "value": 2
+                                "value": 1
                             },
                             {
                                 "kind": "enum-constant",
                                 "name": "OC_FILE_ACCESS_WRITE",
                                 "doc": "The file handle can be used for writing to the file.",
-                                "value": 4
+                                "value": 2
                             }
                         ]
                     }

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -40,14 +40,14 @@ typedef u32 oc_window_style;
 
 enum oc_window_style_enum
 {
-    OC_WINDOW_STYLE_NO_TITLE = 0x01 << 0,
-    OC_WINDOW_STYLE_FIXED_SIZE = 0x01 << 1,
-    OC_WINDOW_STYLE_NO_CLOSE = 0x01 << 2,
-    OC_WINDOW_STYLE_NO_MINIFY = 0x01 << 3,
-    OC_WINDOW_STYLE_NO_FOCUS = 0x01 << 4,
-    OC_WINDOW_STYLE_FLOAT = 0x01 << 5,
-    OC_WINDOW_STYLE_POPUPMENU = 0x01 << 6,
-    OC_WINDOW_STYLE_NO_BUTTONS = 0x01 << 7
+    OC_WINDOW_STYLE_NO_TITLE = 1 << 0,
+    OC_WINDOW_STYLE_FIXED_SIZE = 1 << 1,
+    OC_WINDOW_STYLE_NO_CLOSE = 1 << 2,
+    OC_WINDOW_STYLE_NO_MINIFY = 1 << 3,
+    OC_WINDOW_STYLE_NO_FOCUS = 1 << 4,
+    OC_WINDOW_STYLE_FLOAT = 1 << 5,
+    OC_WINDOW_STYLE_POPUPMENU = 1 << 6,
+    OC_WINDOW_STYLE_NO_BUTTONS = 1 << 7
 };
 
 typedef enum
@@ -225,12 +225,12 @@ typedef enum
 
 typedef enum
 {
-    OC_KEYMOD_NONE = 0x00,
-    OC_KEYMOD_ALT = 0x01,
-    OC_KEYMOD_SHIFT = 0x02,
-    OC_KEYMOD_CTRL = 0x04,
-    OC_KEYMOD_CMD = 0x08,
-    OC_KEYMOD_MAIN_MODIFIER = 0x10 /* CMD on Mac, CTRL on Win32 */
+    OC_KEYMOD_NONE = 0,
+    OC_KEYMOD_ALT = 1 << 0,
+    OC_KEYMOD_SHIFT = 1 << 1,
+    OC_KEYMOD_CTRL = 1 << 2,
+    OC_KEYMOD_CMD = 1 << 3,
+    OC_KEYMOD_MAIN_MODIFIER = 1 << 4 /* CMD on Mac, CTRL on Win32 */
 } oc_keymod_flags;
 
 typedef enum
@@ -417,7 +417,7 @@ typedef u32 oc_file_dialog_flags;
 
 enum _oc_file_dialog_flags
 {
-    OC_FILE_DIALOG_FILES = 1,
+    OC_FILE_DIALOG_FILES = 1 << 0,
     OC_FILE_DIALOG_DIRECTORIES = 1 << 1,
     OC_FILE_DIALOG_MULTIPLE = 1 << 2,
     OC_FILE_DIALOG_CREATE_DIRECTORIES = 1 << 3,

--- a/src/platform/platform_io.h
+++ b/src/platform/platform_io.h
@@ -28,13 +28,13 @@ typedef u16 oc_file_open_flags;
 enum oc_file_open_flags_enum
 {
     OC_FILE_OPEN_NONE = 0,
-    OC_FILE_OPEN_APPEND = 1 << 1,
-    OC_FILE_OPEN_TRUNCATE = 1 << 2,
-    OC_FILE_OPEN_CREATE = 1 << 3,
+    OC_FILE_OPEN_APPEND = 1 << 0,
+    OC_FILE_OPEN_TRUNCATE = 1 << 1,
+    OC_FILE_OPEN_CREATE = 1 << 2,
 
-    OC_FILE_OPEN_SYMLINK = 1 << 4,
-    OC_FILE_OPEN_NO_FOLLOW = 1 << 5,
-    OC_FILE_OPEN_RESTRICT = 1 << 6,
+    OC_FILE_OPEN_SYMLINK = 1 << 3,
+    OC_FILE_OPEN_NO_FOLLOW = 1 << 4,
+    OC_FILE_OPEN_RESTRICT = 1 << 5,
     //...
 };
 
@@ -43,8 +43,8 @@ typedef u16 oc_file_access;
 enum oc_file_access_enum
 {
     OC_FILE_ACCESS_NONE = 0,
-    OC_FILE_ACCESS_READ = 1 << 1,
-    OC_FILE_ACCESS_WRITE = 1 << 2,
+    OC_FILE_ACCESS_READ = 1 << 0,
+    OC_FILE_ACCESS_WRITE = 1 << 1,
 };
 
 typedef enum


### PR DESCRIPTION
I can't find any cases where the first bit is reserved in the codebase, so I can only assume it was an oversight. 
Though if it was intentional I'd be curious to know why.

I've also taken the liberty of unifying the style for other bitmasks in the codebase, though that commit can be dropped if unwanted.