### PR TITLE
Zero-init arena memory by default

### DIFF
--- a/src/graphics/graphics_common.c
+++ b/src/graphics/graphics_common.c
@@ -410,7 +410,7 @@ oc_font oc_font_create_from_memory(oc_str8 mem, u32 rangeCount, oc_unicode_range
     oc_font_data* font = oc_list_pop_front_entry(&oc_graphicsData.fontFreeList, oc_font_data, freeListElt);
     if(!font)
     {
-        font = oc_arena_push_type(&oc_graphicsData.resourceArena, oc_font_data);
+        font = oc_arena_push_type_uninitialized(&oc_graphicsData.resourceArena, oc_font_data);
     }
     if(font)
     {
@@ -588,7 +588,7 @@ oc_font oc_font_create_from_file(oc_file file, u32 rangeCount, oc_unicode_range*
     oc_arena_scope scratch = oc_scratch_begin();
 
     u64 size = oc_file_size(file);
-    char* buffer = oc_arena_push(scratch.arena, size);
+    char* buffer = oc_arena_push_uninitialized(scratch.arena, size);
     u64 read = oc_file_read(file, size, buffer);
 
     if(read != size)
@@ -684,7 +684,7 @@ oc_str32 oc_font_get_glyph_indices(oc_font font, oc_str32 codePoints, oc_str32 b
 
 oc_str32 oc_font_push_glyph_indices(oc_arena* arena, oc_font font, oc_str32 codePoints)
 {
-    u32* buffer = oc_arena_push_array(arena, u32, codePoints.len);
+    u32* buffer = oc_arena_push_array_uninitialized(arena, u32, codePoints.len);
     oc_str32 backing = { .ptr = buffer, .len = codePoints.len };
     return (oc_font_get_glyph_indices(font, codePoints, backing));
 }
@@ -957,7 +957,7 @@ oc_canvas_context oc_canvas_context_create()
     oc_canvas_context_data* context = oc_list_pop_front_entry(&oc_graphicsData.canvasFreeList, oc_canvas_context_data, freeListElt);
     if(!context)
     {
-        context = oc_arena_push_type(&oc_graphicsData.resourceArena, oc_canvas_context_data);
+        context = oc_arena_push_type_uninitialized(&oc_graphicsData.resourceArena, oc_canvas_context_data);
     }
     if(context)
     {
@@ -1911,7 +1911,7 @@ oc_image oc_image_create_from_file(oc_canvas_renderer renderer, oc_file file, bo
     oc_arena_scope scratch = oc_scratch_begin();
 
     u64 size = oc_file_size(file);
-    char* buffer = oc_arena_push(scratch.arena, size);
+    char* buffer = oc_arena_push_uninitialized(scratch.arena, size);
     u64 read = oc_file_read(file, size, buffer);
 
     if(read != size)
@@ -1998,7 +1998,6 @@ typedef struct oc_rect_atlas
 oc_rect_atlas* oc_rect_atlas_create(oc_arena* arena, i32 width, i32 height)
 {
     oc_rect_atlas* atlas = oc_arena_push_type(arena, oc_rect_atlas);
-    memset(atlas, 0, sizeof(oc_rect_atlas));
     atlas->arena = arena;
     atlas->size = (oc_vec2i){ width, height };
     return (atlas);
@@ -2069,7 +2068,7 @@ oc_image_region oc_image_atlas_alloc_from_file(oc_rect_atlas* atlas, oc_image ba
     oc_arena_scope scratch = oc_scratch_begin();
 
     u64 size = oc_file_size(file);
-    char* buffer = oc_arena_push(scratch.arena, size);
+    char* buffer = oc_arena_push_uninitialized(scratch.arena, size);
     u64 read = oc_file_read(file, size, buffer);
 
     if(read != size)

--- a/src/platform/platform_io_dialog.c
+++ b/src/platform/platform_io_dialog.c
@@ -85,7 +85,6 @@ oc_file_open_with_dialog_result oc_file_open_with_dialog_for_table(oc_arena* are
             }
 
             oc_file_open_with_dialog_elt* resElt = oc_arena_push_type(arena, oc_file_open_with_dialog_elt);
-            memset(resElt, 0, sizeof(*resElt));
             resElt->file = file;
             oc_list_push_back(&result.selection, &resElt->listElt);
 

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -221,9 +221,8 @@ oc_ui_context* oc_ui_context_create(oc_font defaultFont)
     ui->defaultFont = defaultFont;
 
     ui->styleVariables.mask = (4 << 10) - 1;
+    //TODO: we could avoid zero-init with a framecounter for each bucket
     ui->styleVariables.buckets = oc_arena_push_array(ui->frameArena, oc_list, 4 << 10);
-    //TODO: we could avoid this with a framecounter for each bucket
-    memset(ui->styleVariables.buckets, 0, sizeof(oc_list) * (4 << 10));
 
     ui->init = true;
 
@@ -263,7 +262,6 @@ void oc_ui_set_context(oc_ui_context* context)
 oc_ui_stack_elt* oc_ui_stack_push(oc_ui_context* ui, oc_ui_stack_elt** stack)
 {
     oc_ui_stack_elt* elt = oc_arena_push_type(ui->frameArena, oc_ui_stack_elt);
-    memset(elt, 0, sizeof(oc_ui_stack_elt));
     elt->parent = *stack;
     *stack = elt;
     return (elt);
@@ -570,7 +568,6 @@ void oc_ui_style_rule_begin(oc_str8 patternString)
 
             //NOTE: create the rule and put it on the workbench
             oc_ui_style_rule* rule = oc_arena_push_type(ui->frameArena, oc_ui_style_rule);
-            memset(rule, 0, sizeof(oc_ui_style_rule));
             rule->pattern = pattern;
 
             ui->workingRule = rule;
@@ -929,7 +926,6 @@ void oc_ui_var_push(oc_str8 name, oc_ui_value value, bool alwaysSet, oc_list* sc
     if(!stack)
     {
         stack = oc_arena_push_type(ui->frameArena, oc_ui_var_stack);
-        memset(stack, 0, sizeof(oc_ui_var_stack));
 
         stack->name = oc_str8_push_copy(ui->frameArena, name);
         stack->hash = hash;
@@ -1658,7 +1654,6 @@ oc_ui_box* oc_ui_box_begin_str8(oc_str8 string)
 
     //NOTE: create style
     box->targetStyle = oc_arena_push_type(ui->frameArena, oc_ui_style);
-    memset(box->targetStyle, 0, sizeof(oc_ui_style));
 
     //NOTE: set tags, rules and variables
     box->rules = (oc_list){ 0 };
@@ -2311,7 +2306,6 @@ void oc_ui_styling_prepass(oc_ui_context* ui, oc_ui_box* box, oc_list* ruleset)
     oc_arena_scope scratch = oc_scratch_begin();
 
     oc_ui_pattern_specificity* specArray = oc_arena_push_array(scratch.arena, oc_ui_pattern_specificity, OC_UI_ATTRIBUTE_COUNT);
-    memset(specArray, 0, sizeof(oc_ui_pattern_specificity) * OC_UI_ATTRIBUTE_COUNT);
 
     oc_list derivedRules = { 0 };
     oc_list_for(*ruleset, rule, oc_ui_style_rule, rulesetElt)

--- a/src/util/memory.c
+++ b/src/util/memory.c
@@ -83,6 +83,21 @@ void* oc_arena_push(oc_arena* arena, u64 size)
 
 void* oc_arena_push_aligned(oc_arena* arena, u64 size, u32 alignment)
 {
+    void* p = oc_arena_push_aligned_uninitialized(arena, size, alignment);
+    if(size && p)
+    {
+        memset(p, 0, size);
+    }
+    return p;
+}
+
+void* oc_arena_push_uninitialized(oc_arena* arena, u64 size)
+{
+    return oc_arena_push_aligned_uninitialized(arena, size, 1);
+}
+
+void* oc_arena_push_aligned_uninitialized(oc_arena* arena, u64 size, u32 alignment)
+{
     if(!size)
     {
         return (0);

--- a/src/util/memory.h
+++ b/src/util/memory.h
@@ -55,6 +55,9 @@ ORCA_API void oc_arena_cleanup(oc_arena* arena);
 
 ORCA_API void* oc_arena_push(oc_arena* arena, u64 size);
 ORCA_API void* oc_arena_push_aligned(oc_arena* arena, u64 size, u32 alignment);
+ORCA_API void* oc_arena_push_uninitialized(oc_arena* arena, u64 size);
+ORCA_API void* oc_arena_push_aligned_uninitialized(oc_arena* arena, u64 size, u32 alignment);
+
 ORCA_API void oc_arena_clear(oc_arena* arena);
 
 ORCA_API oc_arena_scope oc_arena_scope_begin(oc_arena* arena);
@@ -62,6 +65,9 @@ ORCA_API void oc_arena_scope_end(oc_arena_scope scope);
 
 #define oc_arena_push_type(arena, type) ((type*)oc_arena_push_aligned(arena, sizeof(type), _Alignof(type)))
 #define oc_arena_push_array(arena, type, count) ((type*)oc_arena_push_aligned(arena, sizeof(type) * (count), _Alignof(type)))
+
+#define oc_arena_push_type_uninitialized(arena, type) ((type*)oc_arena_push_aligned_uninitialized(arena, sizeof(type), _Alignof(type)))
+#define oc_arena_push_array_uninitialized(arena, type, count) ((type*)oc_arena_push_aligned_uninitialized(arena, sizeof(type) * (count), _Alignof(type)))
 
 //--------------------------------------------------------------------------------
 //NOTE(martin): memory pool

--- a/src/wasm/backend_bytebox.c
+++ b/src/wasm/backend_bytebox.c
@@ -402,7 +402,6 @@ oc_wasm* oc_wasm_create(void)
     oc_arena_init(&arena);
 
     oc_wasm* wasm = oc_arena_push_type(&arena, oc_wasm);
-    memset(wasm, 0, sizeof(oc_wasm));
 
     wasm->arena = arena;
     oc_list_init(&wasm->bindings);

--- a/src/wasm/backend_wasm3.c
+++ b/src/wasm/backend_wasm3.c
@@ -516,7 +516,6 @@ oc_wasm* oc_wasm_create(void)
     oc_arena_init(&arena);
 
     oc_wasm* wasm = oc_arena_push_type(&arena, oc_wasm);
-    memset(wasm, 0, sizeof(oc_wasm));
 
     wasm->arena = arena;
     oc_list_init(&wasm->bindings);


### PR DESCRIPTION
Zero-initialize memory allocated from arenas by default, and provide an explicit uninitialized variant for when usage code takes care of fully initializing the memory.