### PR TITLE
proposal: store and maintain element count in oc_list

### DIFF
--- a/src/util/lists.c
+++ b/src/util/lists.c
@@ -11,7 +11,7 @@
 
 void oc_list_init(oc_list* list)
 {
-    list->first = list->last = 0;
+    memset(list, 0, sizeof(oc_list));
 }
 
 void oc_list_insert(oc_list* list, oc_list_elt* afterElt, oc_list_elt* elt)
@@ -27,6 +27,7 @@ void oc_list_insert(oc_list* list, oc_list_elt* afterElt, oc_list_elt* elt)
         list->last = elt;
     }
     afterElt->next = elt;
+    list->len++;
 
     OC_DEBUG_ASSERT(elt->next != elt, "oc_list_insert(): can't insert an element into itself");
 }
@@ -46,6 +47,7 @@ void oc_list_insert_before(oc_list* list, oc_list_elt* beforeElt, oc_list_elt* e
     }
     beforeElt->prev = elt;
 
+    list->len++;
     OC_DEBUG_ASSERT(elt->next != elt, "oc_list_insert_before(): can't insert an element into itself");
 }
 
@@ -70,6 +72,8 @@ void oc_list_remove(oc_list* list, oc_list_elt* elt)
         list->last = elt->prev;
     }
     elt->prev = elt->next = 0;
+    OC_DEBUG_ASSERT(list->len);
+    list->len--;
 }
 
 void oc_list_push_front(oc_list* list, oc_list_elt* elt)
@@ -85,6 +89,7 @@ void oc_list_push_front(oc_list* list, oc_list_elt* elt)
         list->last = elt;
     }
     list->first = elt;
+    list->len++;
 }
 
 oc_list_elt* oc_list_pop_front(oc_list* list)
@@ -114,6 +119,7 @@ void oc_list_push_back(oc_list* list, oc_list_elt* elt)
         list->first = elt;
     }
     list->last = elt;
+    list->len++;
 }
 
 oc_list_elt* oc_list_pop_back(oc_list* list)

--- a/src/util/lists.h
+++ b/src/util/lists.h
@@ -77,6 +77,7 @@ typedef struct oc_list
 {
     oc_list_elt* first;
     oc_list_elt* last;
+    u64 len;
 } oc_list;
 
 ORCA_API bool oc_list_empty(oc_list list);


### PR DESCRIPTION
Maintaining a count along an `oc_list` comes up a number of times in the codebase, so it may be useful to add that to the `oc_list` struct itself. Having that would also allow reverse indexed for loops on list (although this usecase it a lot less frequent)

@rdunnington @Parzival-3141 @Skytrias what do you think? And would it cause problems with the language bindings (since it modifies the length of the list struct and might not map 1-to-1 to language native constructs)