### PR TITLE
zig build: add support for building, bundling, and running samples

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -390,6 +390,7 @@ pub fn build(b: *Build) !void {
     try orca_tool_compile_flags.append("-DOC_BUILD_DLL");
     try orca_tool_compile_flags.append("-DCURL_STATICLIB");
     try orca_tool_compile_flags.append(b.fmt("-DORCA_TOOL_VERSION={s}", .{git_version_tool}));
+    try orca_tool_compile_flags.append("-fno-sanitize=undefined"); // seems to be some UB in stb_image when resizing icons :(
 
     if (optimize == .Debug) {
         try orca_tool_compile_flags.append("-DOC_DEBUG");

--- a/samples/ui/src/main.c
+++ b/samples/ui/src/main.c
@@ -467,14 +467,14 @@ ORCA_EXPORT void oc_on_frame_refresh(void)
                     static oc_color unselectedBgColor = { 0 };
                     static oc_color unselectedBorderColor = { 0.976, 0.976, 0.976, 0.35 };
                     static f32 unselectedBorderSize = 1;
-                    static oc_str8 unselectedWhenStatus = OC_STR8("");
+                    oc_str8 unselectedWhenStatus = OC_STR8("");
 
                     static f32 selectedWidth = 16;
                     static f32 selectedHeight = 16;
                     static f32 selectedRoundness = 8;
                     static oc_color selectedCenterColor = { 1, 1, 1, 1 };
                     static oc_color selectedBgColor = { 0.33, 0.66, 1, 1 };
-                    static oc_str8 selectedWhenStatus = OC_STR8("");
+                    oc_str8 selectedWhenStatus = OC_STR8("");
 
                     static oc_color labelFontColor = { 0.976, 0.976, 0.976, 1 };
                     static oc_font* labelFont = &fontRegular;

--- a/samples/ui/src/main.c
+++ b/samples/ui/src/main.c
@@ -467,14 +467,14 @@ ORCA_EXPORT void oc_on_frame_refresh(void)
                     static oc_color unselectedBgColor = { 0 };
                     static oc_color unselectedBorderColor = { 0.976, 0.976, 0.976, 0.35 };
                     static f32 unselectedBorderSize = 1;
-                    oc_str8 unselectedWhenStatus = OC_STR8("");
+                    static oc_str8 unselectedWhenStatus = OC_STR8_LIT("");
 
                     static f32 selectedWidth = 16;
                     static f32 selectedHeight = 16;
                     static f32 selectedRoundness = 8;
                     static oc_color selectedCenterColor = { 1, 1, 1, 1 };
                     static oc_color selectedBgColor = { 0.33, 0.66, 1, 1 };
-                    oc_str8 selectedWhenStatus = OC_STR8("");
+                    static oc_str8 selectedWhenStatus = OC_STR8_LIT("");
 
                     static oc_color labelFontColor = { 0.976, 0.976, 0.976, 1 };
                     static oc_font* labelFont = &fontRegular;


### PR DESCRIPTION
* `build.zig` changes add support for building and running samples
* Fixed nested directories not being created correctly in `oc_sys_mkdirs`
* Disabled UBsan for orca tool - some UB is going on when resizing icons and it seems to work fine with UBsan off. I can look into fixing this in a followup.
* Minor compile error fix in the UI sample - I'm guessing zig turns up some strictness settings compared to default clang

Run the samples with:
```
zig build samples
zig build sample-breakout
zig build sample-clock
zig build sample-XXX
```

Note that the bundling step still relies on the user having an orca install in their `PATH`. This is because the current zig build doesn't setup the zig-out directory to mirror how package-sdk sets up the output directory. Ideally in the future we could run the orca tool out of `zig-out` to avoid having to perform an expensive SDK install.