### PR TITLE
Typed Lists

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -927,7 +927,7 @@ pub fn build(b: *Build) !void {
     };
 
     var gen_host_interface_compile_flags: std.ArrayList([]const u8) = .empty;
-    try gen_host_interface_compile_flags.append(b.allocator, "-std=c11");
+    try gen_host_interface_compile_flags.append(b.allocator, "-std=c23");
     try gen_host_interface_compile_flags.append(b.allocator, "-Werror");
     try gen_host_interface_compile_flags.append(b.allocator, "-g");
     try gen_host_interface_compile_flags.append(b.allocator, "-O0");
@@ -1011,7 +1011,7 @@ pub fn build(b: *Build) !void {
     var orca_platform_compile_flags: std.ArrayList([]const u8) = .empty;
     defer orca_platform_compile_flags.deinit(b.allocator);
     try orca_platform_compile_flags.appendSlice(b.allocator, &.{
-        "-std=c11",
+        "-std=c23",
         "-Werror",
         "-DOC_BUILD_DLL",
         "-D_USE_MATH_DEFINES",
@@ -1145,7 +1145,7 @@ pub fn build(b: *Build) !void {
     warm_lib.addCSourceFiles(.{
         .files = warm_sources,
         .flags = &.{
-            "-std=c11",
+            "-std=c23",
             "-Werror",
             "-g",
             "-O0",
@@ -1167,7 +1167,7 @@ pub fn build(b: *Build) !void {
         try orca_launcher_compile_flags.append(b.allocator, "-DOC_DEBUG");
         try orca_launcher_compile_flags.append(b.allocator, "-DOC_LOG_COMPILE_DEBUG");
     }
-    try orca_launcher_compile_flags.append(b.allocator, "-std=c11");
+    try orca_launcher_compile_flags.append(b.allocator, "-std=c23");
     try orca_launcher_compile_flags.append(b.allocator, "-Werror");
     try orca_launcher_compile_flags.append(b.allocator, b.fmt("-DORCA_TOOL_VERSION={s}", .{git_version_tool}));
 
@@ -1218,7 +1218,7 @@ pub fn build(b: *Build) !void {
         });
     }
     try orca_runtime_compile_flags.appendSlice(b.allocator, &.{
-        "-std=c11",
+        "-std=c23",
         "-Werror",
     });
 
@@ -1316,7 +1316,7 @@ pub fn build(b: *Build) !void {
         "-DBULK_MEMORY_THRESHOLD=32",
 
         // other flags
-        "--std=c11",
+        "--std=c23",
     };
     // zig fmt: on
 

--- a/samples/ui/src/main.c
+++ b/samples/ui/src/main.c
@@ -19,7 +19,7 @@ oc_font fontBold;
 oc_ui_context* ui;
 oc_arena textArena = { 0 };
 oc_arena logArena = { 0 };
-oc_str8_list logLines;
+oc_str8_list logLines = { 0 };
 
 typedef enum cmd
 {
@@ -68,7 +68,6 @@ ORCA_EXPORT void oc_on_init(void)
 
     oc_arena_init(&textArena);
     oc_arena_init(&logArena);
-    oc_list_init(&logLines.list);
 }
 
 ORCA_EXPORT void oc_on_raw_event(oc_event* event)
@@ -431,7 +430,7 @@ ORCA_EXPORT void oc_on_frame_refresh(void)
                             oc_ui_style_set_f32(OC_UI_MARGIN_Y, 16);
                             oc_ui_style_set_i32(OC_UI_AXIS, OC_UI_AXIS_Y);
 
-                            if(oc_list_empty(logLines.list))
+                            if(oc_typed_list_empty(logLines.list))
                             {
                                 oc_ui_style_rule("label")
                                 {

--- a/src/api.json
+++ b/src/api.json
@@ -1353,29 +1353,6 @@
                 },
                 {
                     "kind": "proc",
-                    "name": "oc_list_init",
-                    "doc": "Zero-initializes a linked list.",
-                    "visibiliy": "ORCA_API",
-                    "return": {
-                        "kind": "void"
-                    },
-                    "params": [
-                        {
-                            "name": "list",
-                            "doc": "A pointer to the list to initialize.",
-                            "type": {
-                                "kind": "pointer",
-                                "type": {
-                                    "kind": "namedType",
-                                    "name": "oc_list"
-                                }
-                            }
-                        }
-                    ],
-                    "note": "In C the same result can be achieved with `*list = (oc_list){0}`."
-                },
-                {
-                    "kind": "proc",
                     "name": "oc_list_insert",
                     "doc": "Insert an element in a list after a given element.",
                     "visibiliy": "ORCA_API",
@@ -1612,6 +1589,294 @@
                                     "name": "oc_list"
                                 }
                             }
+                        }
+                    ]
+                },
+                {
+                    "kind": "typename",
+                    "name": "oc_typed_list_links",
+                    "doc": "An element of a typed intrusive doubly-linked list.",
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {
+                                "name": "prev",
+                                "type": {
+                                    "kind": "pointer",
+                                    "type": {
+                                        "kind": "namedType",
+                                        "name": "oc_typed_list_links"
+                                    }
+                                },
+                                "doc": "Points to the previous element in the list."
+                            },
+                            {
+                                "name": "next",
+                                "type": {
+                                    "kind": "pointer",
+                                    "type": {
+                                        "kind": "namedType",
+                                        "name": "oc_typed_list_links"
+                                    }
+                                },
+                                "doc": "Points to the next element in the list."
+                            }
+                        ]
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list",
+                    "doc": "Create a type specification for a typed doubly-linked list. You should use this as `typedef oc_typed_list(myType) myTypeList;`",
+                    "params": [
+                        {
+                            "name": "type",
+                            "doc": "The type of item stored in the list."
+                        },
+                        {
+                            "name": "linksField",
+                            "doc": "The name of the `oc_typed_list_links` field in `type` by which the items are linked in the list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_empty",
+                    "doc": "Check if a list is empty.",
+                    "return": {
+                        "doc": "`true` if the list is empty, `false` otherwise."
+                    },
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` linked list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_first",
+                    "doc": "Get the first element of a list.",
+                    "params": [
+                        {
+                            "name": "l",
+                            "doc": "An `oc_typed_list` list."
+                        }
+                    ],
+                    "return": {
+                        "doc": "A pointer to the first item of the list."
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_last",
+                    "doc": "Returns the last element of a list.",
+                    "params": [
+                        {
+                            "name": "l",
+                            "doc": "An `oc_typed_list` list."
+                        }
+                    ],
+                    "return": {
+                        "doc": "A pointer to the last item of the list."
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_next",
+                    "doc": "Get the next element in a list.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` list."
+                        },
+                        {
+                            "name": "elt",
+                            "doc": "A pointer to an item in a list."
+                        }
+                    ],
+                    "return": {
+                        "doc": "A pointer to the next item in the list."
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_prev",
+                    "doc": "Get the previous element in a list.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` list."
+                        },
+                        {
+                            "name": "elt",
+                            "doc": "A pointer to an item in a list."
+                        }
+                    ],
+                    "return": {
+                        "doc": "A pointer to the previous item in the list."
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_push_front",
+                    "doc": "Add an element at the end of a list.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "The list to add an element to."
+                        },
+                        {
+                            "name": "item",
+                            "doc": "The item to add to the list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_push_back",
+                    "doc": "Add an element at the end of a list.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "The list to add an element to."
+                        },
+                        {
+                            "name": "item",
+                            "doc": "The item to add to the list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_pop_front",
+                    "doc": "Remove the first entry from a list and return it.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` object."
+                        }
+                    ],
+                    "return": {
+                        "doc": "A pointer to the item that was removed from the list."
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_pop_back",
+                    "doc": "Remove the last entry from a list and return it.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` object."
+                        }
+                    ],
+                    "return": {
+                        "doc": "A pointer to the item that was removed from the list."
+                    }
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_linked_list_insert_after",
+                    "doc": "Insert an element in a list after a given element.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` list."
+                        },
+                        {
+                            "name": "after",
+                            "doc": "The item after which to insert."
+                        },
+                        {
+                            "name": "item",
+                            "doc": "The item to insert in the list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_linked_list_insert_before",
+                    "doc": "Insert an element in a list before a given element.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` list."
+                        },
+                        {
+                            "name": "before",
+                            "doc": "The item before which to insert."
+                        },
+                        {
+                            "name": "item",
+                            "doc": "The item to insert in the list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_remove",
+                    "doc": "Remove an element from a typed list.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "The list to remove from."
+                        },
+                        {
+                            "name": "item",
+                            "doc": "The item to remove from the list."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_for",
+                    "doc": [
+                        "Loop through a typed linked list.",
+                        "",
+                        "This macro creates a loop with an iterator named after the `elt` macro parameter. The iterator is of the type of the entries linked in the list.",
+                        "",
+                        "You should follow this macro with the loop body, where you can use the iterator."
+                    ],
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` object."
+                        },
+                        {
+                            "name": "elt",
+                            "doc": "The name of the loop iterator."
+                        }
+                    ],
+                    "note": "You should not add or remove elements from the list inside the loop body. If you need to do so, use `oc_typed_list_for_safe` instead."
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_for_reverse",
+                    "doc": "Loop through a linked list from last to first. See `oc_typed_list_for` for details.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` object."
+                        },
+                        {
+                            "name": "elt",
+                            "doc": "The name of the loop iterator."
+                        }
+                    ]
+                },
+                {
+                    "kind": "macro",
+                    "name": "oc_typed_list_for_safe",
+                    "doc": "Loop through a typed linked list in a way that allows adding or removing elements from it in the loop body. See `oc_typed_list_for` for more details.",
+                    "params": [
+                        {
+                            "name": "list",
+                            "doc": "An `oc_typed_list` object."
+                        },
+                        {
+                            "name": "elt",
+                            "doc": "The name of the loop iterator."
                         }
                     ]
                 }
@@ -2805,7 +3070,7 @@
                                 "doc": "The string element is linked into its parent string list through this field.",
                                 "type": {
                                     "kind": "namedType",
-                                    "name": "oc_list_elt"
+                                    "name": "oc_typed_list_links"
                                 }
                             },
                             {
@@ -2830,26 +3095,77 @@
                                 "name": "list",
                                 "doc": "A linked-list of `oc_str8_elt`.",
                                 "type": {
-                                    "kind": "namedType",
-                                    "name": "oc_list"
+                                        "kind": "union",
+                                        "fields": [
+                                            {
+                                                "name": "",
+                                                "type": {
+                                                    "kind": "struct",
+                                                    "fields": [
+                                                        {
+                                                            "name": "first",
+                                                            "type": {
+                                                                "kind": "pointer",
+                                                                "type": {
+                                                                    "kind": "namedType",
+                                                                    "name": "oc_typed_list_links"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "last",
+                                                            "type": {
+                                                                "kind": "pointer",
+                                                                "type": {
+                                                                    "kind": "namedType",
+                                                                    "name": "oc_typed_list_links"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "count",
+                                                            "type": {
+                                                                "kind": "u64"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "name": "t",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "type": {
+                                                        "kind": "namedType",
+                                                        "name": "oc_str8_elt"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "name": "ofs",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "type": {
+                                                        "kind": "array",
+                                                        "type": {
+                                                            "kind": "char"
+                                                        },
+                                                        "count": 0
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "len",
+                                    "doc": "The total length of the string list, which is the sum of the lengths over all elements.",
+                                    "type": {
+                                        "kind": "u64"
+                                    }
                                 }
-                            },
-                            {
-                                "name": "eltCount",
-                                "doc": "The number of elements in `list`.",
-                                "type": {
-                                    "kind": "u64"
-                                }
-                            },
-                            {
-                                "name": "len",
-                                "doc": "The total length of the string list, which is the sum of the lengths over all elements.",
-                                "type": {
-                                    "kind": "u64"
-                                }
-                            }
-                        ]
-                    }
+                            ]
+                        }
                 },
                 {
                     "kind": "proc",
@@ -3342,7 +3658,7 @@
                 {
                     "kind": "typename",
                     "name": "oc_str16_elt",
-                    "doc": "A type representing an element of an `oc_str16` list.",
+                    "doc": "A type representing an element of a string list.",
                     "type": {
                         "kind": "struct",
                         "fields": [
@@ -3351,7 +3667,7 @@
                                 "doc": "The string element is linked into its parent string list through this field.",
                                 "type": {
                                     "kind": "namedType",
-                                    "name": "oc_list_elt"
+                                    "name": "oc_typed_list_links"
                                 }
                             },
                             {
@@ -3368,6 +3684,7 @@
                 {
                     "kind": "typename",
                     "name": "oc_str16_list",
+                    "doc": "A type representing a string list.",
                     "type": {
                         "kind": "struct",
                         "fields": [
@@ -3375,26 +3692,77 @@
                                 "name": "list",
                                 "doc": "A linked-list of `oc_str16_elt`.",
                                 "type": {
-                                    "kind": "namedType",
-                                    "name": "oc_list"
+                                        "kind": "union",
+                                        "fields": [
+                                            {
+                                                "name": "",
+                                                "type": {
+                                                    "kind": "struct",
+                                                    "fields": [
+                                                        {
+                                                            "name": "first",
+                                                            "type": {
+                                                                "kind": "pointer",
+                                                                "type": {
+                                                                    "kind": "namedType",
+                                                                    "name": "oc_typed_list_links"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "last",
+                                                            "type": {
+                                                                "kind": "pointer",
+                                                                "type": {
+                                                                    "kind": "namedType",
+                                                                    "name": "oc_typed_list_links"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "count",
+                                                            "type": {
+                                                                "kind": "u64"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "name": "t",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "type": {
+                                                        "kind": "namedType",
+                                                        "name": "oc_str16_elt"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "name": "ofs",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "type": {
+                                                        "kind": "array",
+                                                        "type": {
+                                                            "kind": "char"
+                                                        },
+                                                        "count": 0
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "len",
+                                    "doc": "The total length of the string list, which is the sum of the lengths over all elements.",
+                                    "type": {
+                                        "kind": "u64"
+                                    }
                                 }
-                            },
-                            {
-                                "name": "eltCount",
-                                "doc": "The number of elements in `list`.",
-                                "type": {
-                                    "kind": "u64"
-                                }
-                            },
-                            {
-                                "name": "len",
-                                "doc": "The total length of the string list, which is the sum of the lengths over all elements.",
-                                "type": {
-                                    "kind": "u64"
-                                }
-                            }
-                        ]
-                    }
+                            ]
+                        }
                 },
                 {
                     "kind": "proc",
@@ -3782,7 +4150,7 @@
                 {
                     "kind": "typename",
                     "name": "oc_str32_elt",
-                    "doc": "A type representing an element of an `oc_str32` list.",
+                    "doc": "A type representing an element of a string list.",
                     "type": {
                         "kind": "struct",
                         "fields": [
@@ -3791,7 +4159,7 @@
                                 "doc": "The string element is linked into its parent string list through this field.",
                                 "type": {
                                     "kind": "namedType",
-                                    "name": "oc_list_elt"
+                                    "name": "oc_typed_list_links"
                                 }
                             },
                             {
@@ -3808,6 +4176,7 @@
                 {
                     "kind": "typename",
                     "name": "oc_str32_list",
+                    "doc": "A type representing a string list.",
                     "type": {
                         "kind": "struct",
                         "fields": [
@@ -3815,26 +4184,77 @@
                                 "name": "list",
                                 "doc": "A linked-list of `oc_str32_elt`.",
                                 "type": {
-                                    "kind": "namedType",
-                                    "name": "oc_list"
+                                        "kind": "union",
+                                        "fields": [
+                                            {
+                                                "name": "",
+                                                "type": {
+                                                    "kind": "struct",
+                                                    "fields": [
+                                                        {
+                                                            "name": "first",
+                                                            "type": {
+                                                                "kind": "pointer",
+                                                                "type": {
+                                                                    "kind": "namedType",
+                                                                    "name": "oc_typed_list_links"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "last",
+                                                            "type": {
+                                                                "kind": "pointer",
+                                                                "type": {
+                                                                    "kind": "namedType",
+                                                                    "name": "oc_typed_list_links"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "name": "count",
+                                                            "type": {
+                                                                "kind": "u64"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "name": "t",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "type": {
+                                                        "kind": "namedType",
+                                                        "name": "oc_str32_elt"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "name": "ofs",
+                                                "type": {
+                                                    "kind": "pointer",
+                                                    "type": {
+                                                        "kind": "array",
+                                                        "type": {
+                                                            "kind": "char"
+                                                        },
+                                                        "count": 0
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "len",
+                                    "doc": "The total length of the string list, which is the sum of the lengths over all elements.",
+                                    "type": {
+                                        "kind": "u64"
+                                    }
                                 }
-                            },
-                            {
-                                "name": "eltCount",
-                                "doc": "The number of elements in `list`.",
-                                "type": {
-                                    "kind": "u64"
-                                }
-                            },
-                            {
-                                "name": "len",
-                                "doc": "The total length of the string list, which is the sum of the lengths over all elements.",
-                                "type": {
-                                    "kind": "u64"
-                                }
-                            }
-                        ]
-                    }
+                            ]
+                        }
                 },
                 {
                     "kind": "proc",

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -16,7 +16,7 @@ oc_app oc_appData = { 0 };
 
 void oc_init_window_handles()
 {
-    oc_list_init(&oc_appData.windowFreeList);
+    oc_appData.windowFreeList = (oc_list){ 0 };
     for(int i = 0; i < OC_APP_MAX_WINDOWS; i++)
     {
         oc_appData.windowPool[i].generation = 1;
@@ -150,7 +150,7 @@ oc_event* oc_next_event(oc_arena* arena)
 
         if(event->type == OC_EVENT_PATHDROP)
         {
-            u64 pathCount = event->paths.eltCount;
+            u64 pathCount = oc_typed_list_count(event->paths.list);
             event->paths = (oc_str8_list){ 0 };
 
             for(int i = 0; i < pathCount; i++)

--- a/src/app/osx_app.m
+++ b/src/app/osx_app.m
@@ -1925,7 +1925,7 @@ ORCA_API oc_file_dialog_result oc_file_dialog_for_table(oc_allocator* allocator,
           [dialog setDirectoryURL:[NSURL fileURLWithPath:nsPath]];
 
           //NOTE: set filters
-          if(desc->filters.eltCount)
+          if(oc_typed_list_count(desc->filters.list))
           {
               NSMutableArray* fileTypesArray = [NSMutableArray array];
 
@@ -2026,7 +2026,7 @@ int oc_alert_popup(oc_str8 title,
           [string release];
 
           [alert setAlertStyle:NSAlertStyleWarning];
-          result = options.eltCount - ([alert runModal] - NSAlertFirstButtonReturn) - 1;
+          result = oc_typed_list_count(options.list) - ([alert runModal] - NSAlertFirstButtonReturn) - 1;
           [keyWindow makeKeyWindow];
       }
     };

--- a/src/app/win32_app.c
+++ b/src/app/win32_app.c
@@ -1450,9 +1450,9 @@ oc_file_dialog_result oc_file_dialog_for_table(oc_allocator* allocator, oc_file_
             }
 
             //NOTE: set filters
-            if(desc->filters.eltCount)
+            if(oc_typed_list_count(desc->filters.list))
             {
-                COMDLG_FILTERSPEC* filterSpecs = oc_allocator_push_array(scratch.allocator, COMDLG_FILTERSPEC, desc->filters.eltCount);
+                COMDLG_FILTERSPEC* filterSpecs = oc_allocator_push_array(scratch.allocator, COMDLG_FILTERSPEC, oc_typed_list_count(desc->filters.list));
 
                 int i = 0;
                 oc_list_for(desc->filters.list, elt, oc_str8_elt, listElt)
@@ -1559,7 +1559,7 @@ int oc_alert_popup(oc_str8 title,
                    oc_str8_list options)
 {
     oc_scratch scratch = oc_scratch_begin();
-    TASKDIALOG_BUTTON* buttons = oc_allocator_push_array(scratch.allocator, TASKDIALOG_BUTTON, options.eltCount);
+    TASKDIALOG_BUTTON* buttons = oc_allocator_push_array(scratch.allocator, TASKDIALOG_BUTTON, oc_typed_list_count(options.list));
 
     int i = 0;
     oc_list_for(options.list, elt, oc_str8_elt, listElt)
@@ -1595,7 +1595,7 @@ int oc_alert_popup(oc_str8 title,
         .pszMainIcon = TD_WARNING_ICON,
         .pszMainInstruction = messageWide,
         .pszContent = NULL,
-        .cButtons = options.eltCount,
+        .cButtons = oc_typed_list_count(options.list),
         .pButtons = buttons,
         .nDefaultButton = 0,
     };

--- a/src/graphics/wgpu_renderer.c
+++ b/src/graphics/wgpu_renderer.c
@@ -4040,9 +4040,9 @@ void oc_wgpu_canvas_debug_clear_records(oc_canvas_renderer handle)
     {
         oc_wgpu_canvas_renderer* renderer = (oc_wgpu_canvas_renderer*)base;
         oc_arena_clear(&renderer->debugArena);
-        oc_list_init(&renderer->debugRecords);
-        oc_list_init(&renderer->frameCountersFreeList);
-        oc_list_init(&renderer->batchCountersFreeList);
+        renderer->debugRecords = (oc_list){ 0 };
+        renderer->frameCountersFreeList = (oc_list){ 0 };
+        renderer->batchCountersFreeList = (oc_list){ 0 };
         renderer->debugRecordsCount = 0;
     }
 }

--- a/src/platform/native_io.c
+++ b/src/platform/native_io.c
@@ -137,7 +137,7 @@ oc_io_resolve_result oc_io_resolve(oc_allocator* allocator, oc_file_desc rootFd,
     oc_str8_list pathElements = oc_path_split(scratch.allocator, path);
     oc_str8_elt* elt = 0;
 
-    while((elt = oc_list_pop_front_entry(&pathElements.list, oc_str8_elt, listElt)) != 0)
+    while((elt = oc_typed_list_pop_front(&pathElements.list)) != 0)
     {
         if(!oc_str8_cmp(elt->string, OC_STR8(".")))
         {
@@ -191,13 +191,13 @@ oc_io_resolve_result oc_io_resolve(oc_allocator* allocator, oc_file_desc rootFd,
 
             if(status.type == OC_FILE_SYMLINK)
             {
-                if(!oc_list_empty(pathElements.list) && (resolveFlags & OC_FILE_RESOLVE_SYMLINK_DONT_FOLLOW))
+                if(!oc_typed_list_empty(pathElements.list) && (resolveFlags & OC_FILE_RESOLVE_SYMLINK_DONT_FOLLOW))
                 {
                     result.error = OC_IO_ERR_SYMLINK;
                     break;
                 }
 
-                if(oc_list_empty(pathElements.list)
+                if(oc_typed_list_empty(pathElements.list)
                    && ((resolveFlags & OC_FILE_RESOLVE_SYMLINK_DONT_FOLLOW)
                        || (resolveFlags & OC_FILE_RESOLVE_SYMLINK_OPEN_LAST)))
                 {

--- a/src/platform/posix_path.c
+++ b/src/platform/posix_path.c
@@ -121,7 +121,7 @@ oc_str8_list oc_path_split(oc_allocator* allocator, oc_str8 path)
     {
         if(elt->string.len == 0)
         {
-            oc_list_remove(&res.list, &elt->listElt);
+            oc_typed_list_remove(&res.list, elt);
         }
     }
 

--- a/src/platform/win32_path.c
+++ b/src/platform/win32_path.c
@@ -169,7 +169,7 @@ oc_str8_list oc_path_split(oc_allocator* allocator, oc_str8 path)
     {
         if(elt->string.len == 0)
         {
-            oc_list_remove(&res.list, &elt->listElt);
+            oc_typed_list_remove(&res.list, elt);
         }
     }
 

--- a/src/runtime/main.c
+++ b/src/runtime/main.c
@@ -107,7 +107,7 @@ oc_event* queue_next_event(oc_arena* arena, oc_ringbuffer* queue)
 
         if(event->type == OC_EVENT_PATHDROP)
         {
-            u64 pathCount = event->paths.eltCount;
+            u64 pathCount = oc_typed_list_count(event->paths.list);
             event->paths = (oc_str8_list){ 0 };
 
             for(int i = 0; i < pathCount; i++)

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1649,7 +1649,7 @@ oc_ui_box* oc_ui_box_begin_str8(oc_str8 string)
     //NOTE: setup hierarchy
     if(box->frameCounter != ui->frameCounter)
     {
-        oc_list_init(&box->children);
+        box->children = (oc_list){ 0 };
         box->childCount = 0;
         box->parent = oc_ui_box_top();
         if(box->parent)

--- a/src/util/lists.c
+++ b/src/util/lists.c
@@ -9,12 +9,6 @@
 
 #include "lists.h"
 
-void oc_list_init(oc_list* list)
-{
-    list->first = list->last = 0;
-    list->count = 0;
-}
-
 void oc_list_insert(oc_list* list, oc_list_elt* afterElt, oc_list_elt* elt)
 {
     elt->prev = afterElt;
@@ -139,4 +133,158 @@ oc_list_elt* oc_list_pop_back(oc_list* list)
 bool oc_list_empty(oc_list list)
 {
     return (list.first == 0 || list.last == 0);
+}
+
+//-------------------------------------------------------------------------
+// Typed intrusive linked lists
+//-------------------------------------------------------------------------
+#define oc_typed_list_entry_generic(links, linksOffset) \
+    (links ? ((char*)links - linksOffset) : 0)
+
+#define oc_typed_list_links_generic(item, linksOffset) \
+    ((oc_typed_list_links*)((char*)item + linksOffset))
+
+void* oc_typed_list_next_generic(void* item, u64 linksOffset)
+{
+    oc_typed_list_links* links = oc_typed_list_links_generic(item, linksOffset);
+    return oc_typed_list_entry_generic(links->next, linksOffset);
+}
+
+void* oc_typed_list_prev_generic(void* item, u64 linksOffset)
+{
+    oc_typed_list_links* links = oc_typed_list_links_generic(item, linksOffset);
+    return oc_typed_list_entry_generic(links->prev, linksOffset);
+}
+
+void oc_typed_list_push_front_generic(oc_typed_list* list, void* item, oc_typed_list_links* elt)
+{
+    (void)item;
+
+    elt->next = list->first;
+    elt->prev = 0;
+    if(list->first)
+    {
+        list->first->prev = elt;
+    }
+    else
+    {
+        list->last = elt;
+    }
+    list->first = elt;
+    list->count++;
+}
+
+void oc_typed_list_push_back_generic(oc_typed_list* list, void* item, oc_typed_list_links* elt)
+{
+    (void)item;
+
+    elt->prev = list->last;
+    elt->next = 0;
+    if(list->last)
+    {
+        list->last->next = elt;
+    }
+    else
+    {
+        list->first = elt;
+    }
+    list->last = elt;
+    list->count++;
+}
+
+void oc_typed_list_remove_generic(oc_typed_list* list, void* item, oc_typed_list_links* links)
+{
+    (void)item;
+
+    if(links->prev)
+    {
+        links->prev->next = links->next;
+    }
+    else
+    {
+        OC_DEBUG_ASSERT(list->first == links);
+        list->first = links->next;
+    }
+    if(links->next)
+    {
+        links->next->prev = links->prev;
+    }
+    else
+    {
+        OC_DEBUG_ASSERT(list->last == links);
+        list->last = links->prev;
+    }
+    links->prev = links->next = 0;
+
+    OC_DEBUG_ASSERT(list->count);
+    list->count--;
+}
+
+void* oc_typed_list_pop_front_generic(oc_typed_list* list, u64 linksOffset)
+{
+    oc_typed_list_links* links = list->first;
+    if(links)
+    {
+        void* item = oc_typed_list_entry_generic(links, linksOffset);
+        oc_typed_list_remove_generic(list, item, links);
+        return item;
+    }
+    else
+    {
+        return (0);
+    }
+}
+
+void* oc_typed_list_pop_back_generic(oc_typed_list* list, u64 linksOffset)
+{
+    oc_typed_list_links* links = list->last;
+    if(links)
+    {
+        void* item = oc_typed_list_entry_generic(links, linksOffset);
+        oc_typed_list_remove_generic(list, item, links);
+        return item;
+    }
+    else
+    {
+        return (0);
+    }
+}
+
+void oc_typed_list_insert_before_generic(oc_typed_list* list, void* item, oc_typed_list_links* before, oc_typed_list_links* links)
+{
+    (void)item;
+
+    links->next = before;
+    links->prev = before->prev;
+
+    if(before->prev)
+    {
+        before->prev->next = links;
+    }
+    else
+    {
+        list->first = links;
+    }
+    before->prev = links;
+    list->count++;
+    OC_DEBUG_ASSERT(links->next != links, "oc_typed_list_insert_before(): can't insert an element into itself");
+}
+
+void oc_typed_list_insert_after_generic(oc_typed_list* list, void* item, oc_typed_list_links* after, oc_typed_list_links* links)
+{
+    (void)item;
+
+    links->prev = after;
+    links->next = after->next;
+    if(after->next)
+    {
+        after->next->prev = links;
+    }
+    else
+    {
+        list->last = links;
+    }
+    after->next = links;
+    list->count++;
+    OC_DEBUG_ASSERT(links->next != links, "oc_typed_list_insert(): can't insert an element into itself");
 }

--- a/src/util/lists.h
+++ b/src/util/lists.h
@@ -89,7 +89,6 @@ typedef struct oc_list
 } oc_list;
 
 ORCA_API bool oc_list_empty(oc_list list);
-ORCA_API void oc_list_init(oc_list* list);
 ORCA_API void oc_list_insert(oc_list* list, oc_list_elt* afterElt, oc_list_elt* elt);
 ORCA_API void oc_list_insert_before(oc_list* list, oc_list_elt* beforeElt, oc_list_elt* elt);
 ORCA_API void oc_list_remove(oc_list* list, oc_list_elt* elt);
@@ -97,6 +96,108 @@ ORCA_API void oc_list_push_front(oc_list* list, oc_list_elt* elt);
 ORCA_API oc_list_elt* oc_list_pop_front(oc_list* list);
 ORCA_API void oc_list_push_back(oc_list* list, oc_list_elt* elt);
 ORCA_API oc_list_elt* oc_list_pop_back(oc_list* list);
+
+//-------------------------------------------------------------------------
+// Typed intrusive linked lists
+//-------------------------------------------------------------------------
+
+typedef struct oc_typed_list_links oc_typed_list_links;
+
+typedef struct oc_typed_list_links
+{
+    oc_typed_list_links* prev;
+    oc_typed_list_links* next;
+} oc_typed_list_links;
+
+typedef struct oc_typed_list
+{
+    oc_typed_list_links* first;
+    oc_typed_list_links* last;
+    u64 count;
+} oc_typed_list;
+
+#define oc_typed_list(type, link)          \
+    union                                  \
+    {                                      \
+        struct                             \
+        {                                  \
+            oc_typed_list_links* first;    \
+            oc_typed_list_links* last;     \
+            u64 count;                     \
+        };                                 \
+        type* t;                           \
+        char (*ofs)[offsetof(type, link)]; \
+    }
+
+//NOTE: these macros typecheck that item arguments are of the correct type for the list argument,
+// and return items of the correct type.
+#define oc_typed_list_count(list) (list).count
+#define oc_typed_list_empty(list) (oc_typed_list_count(list) == 0)
+
+#define oc_typed_list_first(list) ((typeof((list).t))oc_typed_list_entry((list), (list).first))
+#define oc_typed_list_last(list) oc_typed_list_entry((list), (list).last)
+
+#define oc_typed_list_next(list, item) \
+    ((typeof(list.t)(*)(typeof(list.t), u64))oc_typed_list_next_generic)(item, oc_typed_list_links_offset(list))
+
+#define oc_typed_list_prev(list, item) \
+    ((typeof(list.t)(*)(typeof(list.t), u64))oc_typed_list_prev_generic)(item, oc_typed_list_links_offset(list))
+
+#define oc_typed_list_push_front(list, item) \
+    ((void (*)(typeof(list), typeof((list)->t), oc_typed_list_links*))oc_typed_list_push_front_generic)(list, item, oc_typed_list_links(*(list), item))
+
+#define oc_typed_list_push_back(list, item) \
+    ((void (*)(typeof(list), typeof((list)->t), oc_typed_list_links*))oc_typed_list_push_back_generic)(list, item, oc_typed_list_links(*(list), item))
+
+#define oc_typed_list_remove(list, item) \
+    ((void (*)(typeof(list), typeof((list)->t), oc_typed_list_links*))oc_typed_list_remove_generic)(list, item, oc_typed_list_links(*(list), item))
+
+#define oc_typed_list_pop_front(list) \
+    ((typeof((list)->t)(*)(typeof(list), u64))oc_typed_list_pop_front_generic)(list, oc_typed_list_links_offset(*(list)))
+
+#define oc_typed_list_pop_back(list) \
+    ((typeof((list)->t)(*)(typeof(list), u64))oc_typed_list_pop_back_generic)(list, oc_typed_list_links_offset(*(list)))
+
+#define oc_typed_list_insert_before(list, before, item)                                                                           \
+    ((void (*)(typeof(list), typeof((list)->t), oc_typed_list_links*, oc_typed_list_links*))oc_typed_list_insert_before_generic)( \
+        list,                                                                                                                     \
+        item,                                                                                                                     \
+        oc_typed_list_links(*(list), before),                                                                                     \
+        oc_typed_list_links(*(list), item))
+
+#define oc_typed_list_insert_after(list, after, item)                                                                            \
+    ((void (*)(typeof(list), typeof((list)->t), oc_typed_list_links*, oc_typed_list_links*))oc_typed_list_insert_after_generic)( \
+        list,                                                                                                                    \
+        item,                                                                                                                    \
+        oc_typed_list_links(*(list), after),                                                                                     \
+        oc_typed_list_links(*(list), item))
+
+//NOTE: list loops
+#define oc_typed_list_for(list, it)                      \
+    for(typeof((list).t) it = oc_typed_list_first(list); \
+        it != 0;                                         \
+        it = oc_typed_list_next(list, it))
+
+#define oc_typed_list_for_reverse(list, it)             \
+    for(typeof((list).t) it = oc_typed_list_last(list); \
+        it != 0;                                        \
+        it = oc_typed_list_prev(list, it))
+
+//NOTE: (internal) generic typed list functions and macros
+
+#define oc_typed_list_links_offset(list) sizeof(*((list).ofs))
+#define oc_typed_list_links(list, item) ((oc_typed_list_links*)(((char*)item) + oc_typed_list_links_offset(list)))
+#define oc_typed_list_entry(list, links) ((typeof((list).t))(links - oc_typed_list_links_offset(list)))
+
+ORCA_API void* oc_typed_list_next_generic(void* item, u64 linksOffset);
+ORCA_API void* oc_typed_list_prev_generic(void* item, u64 linksOffset);
+ORCA_API void oc_typed_list_push_front_generic(oc_typed_list* list, void* item, oc_typed_list_links* elt);
+ORCA_API void oc_typed_list_push_back_generic(oc_typed_list* list, void* item, oc_typed_list_links* elt);
+ORCA_API void oc_typed_list_remove_generic(oc_typed_list* list, void* item, oc_typed_list_links* links);
+ORCA_API void* oc_typed_list_pop_front_generic(oc_typed_list* list, u64 linksOffset);
+ORCA_API void* oc_typed_list_pop_back_generic(oc_typed_list* list, u64 linksOffset);
+ORCA_API void oc_typed_list_insert_before_generic(oc_typed_list* list, void* item, oc_typed_list_links* before, oc_typed_list_links* links);
+ORCA_API void oc_typed_list_insert_after_generic(oc_typed_list* list, void* item, oc_typed_list_links* after, oc_typed_list_links* links);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/util/strings.c
+++ b/src/util/strings.c
@@ -112,8 +112,7 @@ int oc_str8_cmp(oc_str8 s1, oc_str8 s2)
 
 void oc_str8_list_init(oc_str8_list* list)
 {
-    oc_list_init(&list->list);
-    list->eltCount = 0;
+    list->list = (typeof(list->list)){ 0 };
     list->len = 0;
 }
 
@@ -121,8 +120,7 @@ void oc_str8_list_push(oc_allocator* allocator, oc_str8_list* list, oc_str8 str)
 {
     oc_str8_elt* elt = oc_allocator_push_type(allocator, oc_str8_elt);
     elt->string = str;
-    oc_list_push_back(&list->list, &elt->listElt);
-    list->eltCount++;
+    oc_typed_list_push_back(&list->list, elt);
     list->len += str.len;
 }
 
@@ -130,10 +128,9 @@ oc_str8 oc_str8_list_pop_back(oc_str8_list* list)
 {
     oc_str8 string = { 0 };
 
-    oc_str8_elt* elt = oc_list_pop_back_entry(&list->list, oc_str8_elt, listElt);
+    oc_str8_elt* elt = oc_typed_list_pop_back(&list->list);
     if(elt)
     {
-        list->eltCount--;
         OC_DEBUG_ASSERT(elt->string.len < list->len);
         list->len -= elt->string.len;
         string = elt->string;
@@ -145,8 +142,7 @@ void oc_str8_list_push_front(oc_allocator* allocator, oc_str8_list* list, oc_str
 {
     oc_str8_elt* elt = oc_allocator_push_type(allocator, oc_str8_elt);
     elt->string = str;
-    oc_list_push_front(&list->list, &elt->listElt);
-    list->eltCount++;
+    oc_typed_list_push_front(&list->list, elt);
     list->len += str.len;
 }
 
@@ -154,10 +150,9 @@ oc_str8 oc_str8_list_pop_front(oc_str8_list* list)
 {
     oc_str8 string = { 0 };
 
-    oc_str8_elt* elt = oc_list_pop_front_entry(&list->list, oc_str8_elt, listElt);
+    oc_str8_elt* elt = oc_typed_list_pop_front(&list->list);
     if(elt)
     {
-        list->eltCount--;
         OC_DEBUG_ASSERT(elt->string.len < list->len);
         list->len -= elt->string.len;
         string = elt->string;
@@ -178,9 +173,9 @@ oc_str8 oc_str8_list_collate(oc_allocator* allocator, oc_str8_list list, oc_str8
 {
     oc_str8 str = { 0 };
     str.len = prefix.len + list.len + postfix.len;
-    if(list.eltCount && separator.len)
+    if(oc_typed_list_count(list.list) && separator.len)
     {
-        str.len += list.eltCount * separator.len - 1;
+        str.len += oc_typed_list_count(list.list) * separator.len - 1;
     }
 
     str.ptr = oc_allocator_push_array(allocator, char, str.len + 1);
@@ -188,15 +183,15 @@ oc_str8 oc_str8_list_collate(oc_allocator* allocator, oc_str8_list list, oc_str8
     memcpy(dst, prefix.ptr, prefix.len);
     dst += prefix.len;
 
-    oc_str8_elt* elt = oc_list_first_entry(list.list, oc_str8_elt, listElt);
+    oc_str8_elt* elt = oc_typed_list_first(list.list);
     if(elt)
     {
         memcpy(dst, elt->string.ptr, elt->string.len);
         dst += elt->string.len;
-        elt = oc_list_next_entry(elt, oc_str8_elt, listElt);
+        elt = oc_typed_list_next(list.list, elt);
     }
 
-    for(; elt != 0; elt = oc_list_next_entry(elt, oc_str8_elt, listElt))
+    for(; elt != 0; elt = oc_typed_list_next(list.list, elt))
     {
         memcpy(dst, separator.ptr, separator.len);
         dst += separator.len;
@@ -217,7 +212,6 @@ oc_str8 oc_str8_list_join(oc_allocator* allocator, oc_str8_list list)
 oc_str8_list oc_str8_split(oc_allocator* allocator, oc_str8 str, oc_str8_list separators)
 {
     oc_str8_list list = { 0 };
-    oc_list_init(&list.list);
 
     char* ptr = str.ptr;
     char* end = str.ptr + str.len;
@@ -226,7 +220,7 @@ oc_str8_list oc_str8_split(oc_allocator* allocator, oc_str8 str, oc_str8_list se
     {
         //NOTE(martin): search all separators and try to match them to the current ptr
         oc_str8* foundSep = 0;
-        oc_list_for(separators.list, elt, oc_str8_elt, listElt)
+        oc_typed_list_for(separators.list, elt)
         {
             oc_str8* separator = &elt->string;
             bool equal = true;
@@ -300,8 +294,7 @@ oc_str16 oc_str16_push_slice(oc_allocator* allocator, oc_str16 s, u64 start, u64
 
 void oc_str16_list_init(oc_str16_list* list)
 {
-    oc_list_init(&list->list);
-    list->eltCount = 0;
+    list->list = (typeof(list->list)){ 0 };
     list->len = 0;
 }
 
@@ -309,29 +302,28 @@ void oc_str16_list_push(oc_allocator* allocator, oc_str16_list* list, oc_str16 s
 {
     oc_str16_elt* elt = oc_allocator_push_type(allocator, oc_str16_elt);
     elt->string = str;
-    oc_list_push_back(&list->list, &elt->listElt);
-    list->eltCount++;
+    oc_typed_list_push_back(&list->list, elt);
     list->len += str.len;
 }
 
 oc_str16 oc_str16_list_collate(oc_allocator* allocator, oc_str16_list list, oc_str16 prefix, oc_str16 separator, oc_str16 postfix)
 {
     oc_str16 str = { 0 };
-    str.len = prefix.len + list.len + list.eltCount * separator.len + postfix.len;
+    str.len = prefix.len + list.len + oc_typed_list_count(list.list) * separator.len + postfix.len;
     str.ptr = oc_allocator_push_array(allocator, u16, str.len + 1);
     char* dst = (char*)str.ptr;
     memcpy(dst, prefix.ptr, prefix.len * sizeof(u16));
     dst += prefix.len * sizeof(u16);
 
-    oc_str16_elt* elt = oc_list_first_entry(list.list, oc_str16_elt, listElt);
+    oc_str16_elt* elt = oc_typed_list_first(list.list);
     if(elt)
     {
         memcpy(dst, elt->string.ptr, elt->string.len * sizeof(u16));
         dst += elt->string.len * sizeof(u16);
-        elt = oc_list_next_entry(elt, oc_str16_elt, listElt);
+        elt = oc_typed_list_next(list.list, elt);
     }
 
-    for(; elt != 0; elt = oc_list_next_entry(elt, oc_str16_elt, listElt))
+    for(; elt != 0; elt = oc_typed_list_next(list.list, elt))
     {
         memcpy(dst, separator.ptr, separator.len * sizeof(u16));
         dst += separator.len * sizeof(u16);
@@ -393,8 +385,7 @@ oc_str32 oc_str32_push_slice(oc_allocator* allocator, oc_str32 s, u64 start, u64
 
 void oc_str32_list_init(oc_str32_list* list)
 {
-    oc_list_init(&list->list);
-    list->eltCount = 0;
+    list->list = (typeof(list->list)){ 0 };
     list->len = 0;
 }
 
@@ -402,29 +393,28 @@ void oc_str32_list_push(oc_allocator* allocator, oc_str32_list* list, oc_str32 s
 {
     oc_str32_elt* elt = oc_allocator_push_type(allocator, oc_str32_elt);
     elt->string = str;
-    oc_list_push_back(&list->list, &elt->listElt);
-    list->eltCount++;
+    oc_typed_list_push_back(&list->list, elt);
     list->len += str.len;
 }
 
 oc_str32 oc_str32_list_collate(oc_allocator* allocator, oc_str32_list list, oc_str32 prefix, oc_str32 separator, oc_str32 postfix)
 {
     oc_str32 str = { 0 };
-    str.len = prefix.len + list.len + list.eltCount * separator.len + postfix.len;
+    str.len = prefix.len + list.len + oc_typed_list_count(list.list) * separator.len + postfix.len;
     str.ptr = oc_allocator_push_array(allocator, u32, str.len + 1);
     char* dst = (char*)str.ptr;
     memcpy(dst, prefix.ptr, prefix.len * sizeof(u32));
     dst += prefix.len * sizeof(u32);
 
-    oc_str32_elt* elt = oc_list_first_entry(list.list, oc_str32_elt, listElt);
+    oc_str32_elt* elt = oc_typed_list_first(list.list);
     if(elt)
     {
         memcpy(dst, elt->string.ptr, elt->string.len * sizeof(u32));
         dst += elt->string.len * sizeof(u32);
-        elt = oc_list_next_entry(elt, oc_str32_elt, listElt);
+        elt = oc_typed_list_next(list.list, elt);
     }
 
-    for(; elt != 0; elt = oc_list_next_entry(elt, oc_str32_elt, listElt))
+    for(; elt != 0; elt = oc_typed_list_next(list.list, elt))
     {
         memcpy(dst, separator.ptr, separator.len * sizeof(u32));
         dst += separator.len * sizeof(u32);

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -68,14 +68,13 @@ ORCA_API char* oc_str8_to_cstring(oc_allocator* allocator, oc_str8 string);
 //----------------------------------------------------------------------------------
 typedef struct oc_str8_elt
 {
-    oc_list_elt listElt;
+    oc_typed_list_links listElt;
     oc_str8 string;
 } oc_str8_elt;
 
 typedef struct oc_str8_list
 {
-    oc_list list;
-    u64 eltCount;
+    oc_typed_list(oc_str8_elt, listElt) list;
     u64 len;
 } oc_str8_list;
 
@@ -90,10 +89,10 @@ ORCA_API oc_str8 oc_str8_list_collate(oc_allocator* allocator, oc_str8_list list
 ORCA_API oc_str8 oc_str8_list_join(oc_allocator* allocator, oc_str8_list list);
 ORCA_API oc_str8_list oc_str8_split(oc_allocator* allocator, oc_str8 str, oc_str8_list separators);
 
-#define oc_str8_list_first(sl) (oc_list_empty(sl.list) ? (oc_str8){ 0 } : (oc_list_first_entry(sl.list, oc_str8_elt, listElt)->string))
-#define oc_str8_list_last(sl) (oc_list_empty(sl.list) ? (oc_str8){ 0 } : (oc_list_last_entry(sl.list, oc_str8_elt, listElt)->string))
-#define oc_str8_list_for(sl, elt) oc_list_for(sl.list, elt, oc_str8_elt, listElt)
-#define oc_str8_list_empty(sl) (oc_list_empty(sl.list))
+#define oc_str8_list_first(sl) (oc_typed_list_empty(sl.list) ? (oc_str8){ 0 } : (oc_typed_list_first(sl.list)->string))
+#define oc_str8_list_last(sl) (oc_typed_list_empty(sl.list) ? (oc_str8){ 0 } : (oc_typed_list_last(sl.list)->string))
+#define oc_str8_list_for(sl, elt) oc_typed_list_for(sl.list, elt)
+#define oc_str8_list_empty(sl) (oc_typed_list_empty(sl.list))
 
 // Allows use of oc_str8 with standard printf via the %.*s specifier
 #define oc_str8_printf(str) (int)str.len, str.ptr
@@ -116,14 +115,13 @@ ORCA_API oc_str16 oc_str16_push_slice(oc_allocator* allocator, oc_str16 s, u64 s
 
 typedef struct oc_str16_elt
 {
-    oc_list_elt listElt;
+    oc_typed_list_links listElt;
     oc_str16 string;
 } oc_str16_elt;
 
 typedef struct oc_str16_list
 {
-    oc_list list;
-    u64 eltCount;
+    oc_typed_list(oc_str16_elt, listElt) list;
     u64 len;
 } oc_str16_list;
 
@@ -131,10 +129,10 @@ ORCA_API void oc_str16_list_push(oc_allocator* allocator, oc_str16_list* list, o
 ORCA_API oc_str16 oc_str16_list_join(oc_allocator* allocator, oc_str16_list list);
 ORCA_API oc_str16_list oc_str16_split(oc_allocator* allocator, oc_str16 str, oc_str16_list separators);
 
-#define oc_str16_list_first(sl) (oc_list_empty(sl.list) ? (oc_str16){ 0 } : (oc_list_first_entry(sl.list, oc_str16_elt, listElt)->string))
-#define oc_str16_list_last(sl) (oc_list_empty(sl.list) ? (oc_str16){ 0 } : (oc_list_last_entry(sl.list, oc_str16_elt, listElt)->string))
-#define oc_str16_list_for(sl, elt) oc_list_for(sl.list, elt, oc_str16_elt, listElt)
-#define oc_str16_list_empty(sl) (oc_list_empty(sl.list))
+#define oc_str16_list_first(sl) (oc_typed_list_empty(sl.list) ? (oc_str16){ 0 } : (oc_typed_list_first(sl.list)->string))
+#define oc_str16_list_last(sl) (oc_typed_list_empty(sl.list) ? (oc_str16){ 0 } : (oc_typed_list_last(sl.list)->string))
+#define oc_str16_list_for(sl, elt) oc_typed_list_for(sl.list, elt)
+#define oc_str16_list_empty(sl) (oc_typed_list_empty(sl.list))
 
 //----------------------------------------------------------------------------------
 // u32 strings
@@ -154,14 +152,13 @@ ORCA_API oc_str32 oc_str32_push_slice(oc_allocator* allocator, oc_str32 s, u64 s
 
 typedef struct oc_str32_elt
 {
-    oc_list_elt listElt;
+    oc_typed_list_links listElt;
     oc_str32 string;
 } oc_str32_elt;
 
 typedef struct oc_str32_list
 {
-    oc_list list;
-    u64 eltCount;
+    oc_typed_list(oc_str32_elt, listElt) list;
     u64 len;
 } oc_str32_list;
 
@@ -169,10 +166,10 @@ ORCA_API void oc_str32_list_push(oc_allocator* allocator, oc_str32_list* list, o
 ORCA_API oc_str32 oc_str32_list_join(oc_allocator* allocator, oc_str32_list list);
 ORCA_API oc_str32_list oc_str32_split(oc_allocator* allocator, oc_str32 str, oc_str32_list separators);
 
-#define oc_str32_list_first(sl) (oc_list_empty(sl.list) ? (oc_str32){ 0 } : (oc_list_first_entry(sl.list, oc_str32_elt, listElt)->string))
-#define oc_str32_list_last(sl) (oc_list_empty(sl.list) ? (oc_str32){ 0 } : (oc_list_last_entry(sl.list, oc_str32_elt, listElt)->string))
-#define oc_str32_list_for(sl, elt) oc_list_for(sl.list, elt, oc_str32_elt, listElt)
-#define oc_str32_list_empty(sl) (oc_list_empty(sl.list))
+#define oc_str32_list_first(sl) (oc_typed_list_empty(sl.list) ? (oc_str32){ 0 } : (oc_typed_list_first(sl.list)->string))
+#define oc_str32_list_last(sl) (oc_typed_list_empty(sl.list) ? (oc_str32){ 0 } : (oc_typed_list_last(sl.list)->string))
+#define oc_str32_list_for(sl, elt) oc_typed_list_for(sl.list, elt)
+#define oc_str32_list_empty(sl) (oc_typed_list_empty(sl.list))
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
This adds a _typed_ instrusive doubly-linked list type to `util/lists.h`. 

It works the same way as the existing untyped `oc_list` type, but ensures that a given list can only contain items of a single type, and that these items are all linked through the same pair of next/prev pointers. This also simplifies APIs for manipulating the list and idioms like loops, since we don't have to pass the type of elements and the name of the link-pair field. 

Usage is as follows:
```
typedef struct my_type 
{
    oc_typed_list_links links;
    int i;
} my_type;

 // declare a type for a linked list that can hold items of type my_type, linked through the links field.
typedef oc_typed_list(my_type, links) my_type_list;

// Create a list and push some items
my_type_list list = {0};
my_type t1 = {.i = 1}, t2 = {.i = 2}, t3 = {.i = 3};

oc_typed_list_push_back(&list, &t1);
oc_typed_list_push_back(&list, &t2);
oc_typed_list_push_back(&list, &t3);

// Loop through the list and print items
oc_typed_list_for(list, elt)
{
    printf("%i ", elt->i);
}

```